### PR TITLE
제스처 처리 로직을 캡슐화하여 제스처 관련 버그 해결

### DIFF
--- a/lib/app/ux/popover.dart
+++ b/lib/app/ux/popover.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 /// 주어진 [Popover] 인스턴스에 따라 해당 오버레이에 표시할 위젯을 생성합니다.
 typedef PopoverBuilder = Widget Function(Popover popover);
@@ -26,10 +27,7 @@ class Popover {
         return Stack(
           children: [
             Positioned.fill(
-              child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onTap: hide,
-              ),
+              child: GrimityGesture(onTap: hide),
             ),
             CompositedTransformFollower(
               link: targetLink,

--- a/lib/presentation/album_edit/view/album_edit_view.dart
+++ b/lib/presentation/album_edit/view/album_edit_view.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/presentation/album_edit/provider/album_edit_provider.dart';
 import 'package:grimity/presentation/album_edit/view/album_reorderable_list_view.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 
 class AlbumEditListView extends ConsumerWidget {
@@ -23,8 +24,7 @@ class AlbumEditListView extends ConsumerWidget {
             Text('앨범 목록', style: AppTypeface.caption1.copyWith(color: AppColor.gray800)),
             const Spacer(),
             if (albums.isNotEmpty)
-              GestureDetector(
-                behavior: HitTestBehavior.translucent,
+              GrimityGesture(
                 onTap: () => ref.read(albumEditProvider.notifier).toggleIsAlbumSorting(),
                 child: Text(
                   isSorting ? '완료' : '순서 편집',

--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class AlbumEditAppBar extends StatelessWidget implements PreferredSizeWidget {
   const AlbumEditAppBar({super.key});
@@ -13,8 +14,7 @@ class AlbumEditAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => context.pop(),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),

--- a/lib/presentation/album_edit/widget/album_widget.dart
+++ b/lib/presentation/album_edit/widget/album_widget.dart
@@ -8,6 +8,7 @@ import 'package:grimity/domain/entity/album.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/album_edit/provider/album_edit_provider.dart';
 import 'package:grimity/presentation/album_edit/widget/album_delete_dialog.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -63,7 +64,7 @@ class AlbumWidget extends HookConsumerWidget {
                 child: Assets.icons.profileEdit.dragAndDrop.svg(width: 20, height: 20),
               ),
             ] else ...[
-              GestureDetector(
+              GrimityGesture(
                 onTap: () => showAlbumDeleteDialog(context, ref, album),
                 child: Assets.icons.common.close.svg(
                   width: 24.w,

--- a/lib/presentation/album_organize/widget/album_organize_app_bar.dart
+++ b/lib/presentation/album_organize/widget/album_organize_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class AlbumOrganizeAppBar extends StatelessWidget implements PreferredSizeWidget {
   const AlbumOrganizeAppBar({super.key});
@@ -14,8 +15,7 @@ class AlbumOrganizeAppBar extends StatelessWidget implements PreferredSizeWidget
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => context.pop(),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),

--- a/lib/presentation/album_organize/widget/album_organize_fab_button.dart
+++ b/lib/presentation/album_organize/widget/album_organize_fab_button.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/album_organize/provider/album_organize_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class AlbumOrganizeFabButton extends ConsumerWidget with AlbumOrganizeMixin {
   const AlbumOrganizeFabButton({super.key, required this.title, required this.asset, required this.onTap});
@@ -18,7 +19,7 @@ class AlbumOrganizeFabButton extends ConsumerWidget with AlbumOrganizeMixin {
     final state = albumOrganizeState(ref);
     final activeButton = state.ids.isNotEmpty && !state.uploading;
 
-    return GestureDetector(
+    return GrimityGesture(
       onTap: activeButton ? onTap : null,
       child: Container(
         decoration: BoxDecoration(

--- a/lib/presentation/chat/view/chat_scroll_item.dart
+++ b/lib/presentation/chat/view/chat_scroll_item.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/data/model/chat/chat_response.dart';
 import 'package:grimity/presentation/chat/provider/chat_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/check/grimity_check_box.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_image.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -28,8 +29,7 @@ class ChatScrollItem extends ConsumerWidget {
       value: idSelected,
       isVisible: isSelectMode,
       onSelect: () => provider.selectChat(model, !idSelected),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
+      child: GrimityGesture(
         onTap: () {
           // 해당 채팅방 페이지로 이동.
           ChatMessageRoute(model.id).push(context);

--- a/lib/presentation/chat/widgets/chat_floating_action_button.dart
+++ b/lib/presentation/chat/widgets/chat_floating_action_button.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class ChatFloatingActionButton extends StatelessWidget {
   const ChatFloatingActionButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () {
         // 새 메세지 보내기 페이지로 이동.
         NewChatRoute().push(context);

--- a/lib/presentation/chat_message/view/chat_message_app_bar.dart
+++ b/lib/presentation/chat_message/view/chat_message_app_bar.dart
@@ -9,6 +9,7 @@ import 'package:grimity/data/model/user/user_base_response.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/chat_message/components/show_delete_chat_dialog.dart';
 import 'package:grimity/presentation/chat_message/provider/chat_message_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_image.dart';
 
@@ -85,8 +86,7 @@ class _BodyArea extends StatelessWidget {
         ),
 
         // 더보기 버튼 표시.
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
+        GrimityGesture(
           onTap: () => openBottomSheet(context),
           child: Container(
             width: 50,

--- a/lib/presentation/chat_message/view/chat_message_field.dart
+++ b/lib/presentation/chat_message/view/chat_message_field.dart
@@ -10,6 +10,7 @@ import 'package:grimity/presentation/chat_message/view/chat_message_image_view.d
 import 'package:grimity/presentation/common/enum/upload_image_type.dart';
 import 'package:grimity/presentation/common/model/image_item_source.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_button.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 
 class ChatMessageField extends ConsumerWidget {
@@ -104,8 +105,7 @@ class _TextFieldState extends ConsumerState<_TextField> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // 이미지 추가 액션 버튼 표시.
-          GestureDetector(
-            behavior: HitTestBehavior.opaque,
+          GrimityGesture(
             onTap: () async {
               final List<ImageSourceItem>? pickedImages
                   = await PhotoSelectRoute(type: UploadImageType.chat).push(context);

--- a/lib/presentation/chat_message/view/chat_message_fragment.dart
+++ b/lib/presentation/chat_message/view/chat_message_fragment.dart
@@ -11,6 +11,7 @@ import 'package:grimity/presentation/chat_message/provider/chat_message_provider
 import 'package:grimity/presentation/chat_message/view/chat_message_image_view.dart';
 import 'package:grimity/presentation/chat_message/view/chat_message_popover_menu.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class ChatMessageFragment extends ConsumerStatefulWidget {
   const ChatMessageFragment({
@@ -66,7 +67,7 @@ class _ChatMessageFragmentState extends ConsumerState<ChatMessageFragment> {
           alignment: isMe ? Alignment.topRight : Alignment.topLeft,
           child: CompositedTransformTarget(
             link: layerLink,
-            child: GestureDetector(
+            child: GrimityGesture(
               onTap: () {
                 if (!isMe) {
                   // 좋아요, 답장과 같은 액션 버튼 표시.

--- a/lib/presentation/chat_message/view/chat_message_image_gallery.dart
+++ b/lib/presentation/chat_message/view/chat_message_image_gallery.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/chat_message/provider/chat_message_provider.dart';
 import 'package:grimity/presentation/common/model/image_item_source.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/photo_select/widget/photo_asset_thumbnail_widget.dart';
 
 class ChatMessageImageGallery extends ConsumerWidget {
@@ -45,7 +46,7 @@ class ChatMessageImageGallery extends ConsumerWidget {
               // TODO: 이미지 선택 취소 버튼.
               Align(
                 alignment: Alignment.topRight,
-                child: GestureDetector(
+                child: GrimityGesture(
                   onTap: () => provider.removeInputImage(inputImage),
                   child: Padding(
                     padding: EdgeInsets.all(2),

--- a/lib/presentation/chat_message/view/chat_message_popover_menu.dart
+++ b/lib/presentation/chat_message/view/chat_message_popover_menu.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/ux/popover.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/chat_message/provider/chat_message_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class ChatMessagePopoverMenu extends ConsumerWidget {
   const ChatMessagePopoverMenu({
@@ -47,8 +48,7 @@ class ChatMessagePopoverMenu extends ConsumerWidget {
     required SvgGenImage icon,
     required VoidCallback onTap,
   }) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.all(8),

--- a/lib/presentation/chat_new/view/new_chat_scroll_item_view.dart
+++ b/lib/presentation/chat_new/view/new_chat_scroll_item_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grimity/data/model/user/follow_user_response.dart';
 import 'package:grimity/presentation/chat_new/provider/new_chat_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/check/grimity_radio_button.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_profile.dart';
 
@@ -22,8 +23,7 @@ class NewChatScrollItemView extends ConsumerWidget {
 
     final isSelected = data.value!.selectedUserId == model.id;
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: () {
         // 메세지를 보낼 대상으로 선택하기.
         provider.select(model);

--- a/lib/presentation/comment/widget/comment_input_bar.dart
+++ b/lib/presentation/comment/widget/comment_input_bar.dart
@@ -7,6 +7,7 @@ import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/comment/enum/comment_type.dart';
 import 'package:grimity/presentation/comment/provider/comment_input_provider.dart';
 import 'package:grimity/presentation/common/widget/grimity_animation_button.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class CommentInputBar extends HookConsumerWidget {
@@ -87,7 +88,7 @@ class CommentInputBar extends HookConsumerWidget {
                     onChanged: (content) => notifier.updateContent(content),
                   ),
                 ),
-                GestureDetector(
+                GrimityGesture(
                   onTap:
                       !isNotEmpty || state.uploading
                           ? null

--- a/lib/presentation/common/widget/alert/grimity_dialog.dart
+++ b/lib/presentation/common/widget/alert/grimity_dialog.dart
@@ -4,6 +4,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimityDialog extends Dialog {
   const GrimityDialog({
@@ -62,7 +63,7 @@ class GrimityDialog extends Dialog {
               children: [
                 if (cancelText != null) ...[
                   Expanded(
-                    child: GestureDetector(
+                    child: GrimityGesture(
                       onTap: onCancel ?? () => Navigator.of(context).pop(),
                       child: Container(
                         padding: EdgeInsets.symmetric(vertical: 11.h),
@@ -80,7 +81,7 @@ class GrimityDialog extends Dialog {
                 ],
                 if (confirmText != null) ...[
                   Expanded(
-                    child: GestureDetector(
+                    child: GrimityGesture(
                       onTap: onConfirm ?? () => Navigator.of(context).pop(),
                       child: Container(
                         padding: EdgeInsets.symmetric(vertical: 11.h),

--- a/lib/presentation/common/widget/button/grimity_action_button.dart
+++ b/lib/presentation/common/widget/button/grimity_action_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/app/config/app_color.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 /// Action 에서 사용 되는 버튼
 class GrimityActionButton extends StatelessWidget {
@@ -35,10 +36,10 @@ class GrimityActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!showBadge) {
-      return GestureDetector(onTap: onTap, child: icon.svg(width: 24.w, height: 24.w));
+      return GrimityGesture(onTap: onTap, child: icon.svg(width: 24.w, height: 24.w));
     }
 
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onTap,
       child: Stack(
         children: [

--- a/lib/presentation/common/widget/button/grimity_button.dart
+++ b/lib/presentation/common/widget/button/grimity_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 enum ButtonSize { large, medium, small, round }
 
@@ -405,8 +406,7 @@ class GrimityButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: buttonStatus == ButtonStatus.on ? onTap : null,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),

--- a/lib/presentation/common/widget/grimity_animation_button.dart
+++ b/lib/presentation/common/widget/grimity_animation_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimityAnimationButton extends HookWidget {
   const GrimityAnimationButton({super.key, required this.child, required this.onTap});
@@ -12,8 +13,7 @@ class GrimityAnimationButton extends HookWidget {
   Widget build(BuildContext context) {
     final animationController = useAnimationController(duration: const Duration(milliseconds: 160));
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: () {
         onTap();
         animationController.forward(from: 0);

--- a/lib/presentation/common/widget/grimity_gesture.dart
+++ b/lib/presentation/common/widget/grimity_gesture.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+/// 해당 앱에서 사용되는 포괄적인 [GestureDetector] 위젯을 구현합니다.
+class GrimityGesture extends StatelessWidget {
+  const GrimityGesture({
+    super.key,
+    this.onTap,
+    this.onDoubleTap,
+    this.onLongPress,
+    this.child,
+  });
+
+  final VoidCallback? onTap;
+  final VoidCallback? onDoubleTap;
+  final VoidCallback? onLongPress;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      onDoubleTap: onDoubleTap,
+      onLongPress: onLongPress,
+      child: child,
+    );
+  }
+}

--- a/lib/presentation/common/widget/grimity_image_feed.dart
+++ b/lib/presentation/common/widget/grimity_image_feed.dart
@@ -3,6 +3,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/feed.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_highlight_text_span.dart';
 import 'package:grimity/presentation/common/widget/grimity_image.dart';
 import 'package:grimity/presentation/common/widget/grimity_reaction.dart';
@@ -27,7 +28,7 @@ class GrimityImageFeed extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () => FeedDetailRoute(id: feed.id).push(context),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/presentation/common/widget/grimity_reaction.dart
+++ b/lib/presentation/common/widget/grimity_reaction.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_gray_circle.dart';
 
 class GrimityReaction extends StatelessWidget {
@@ -57,7 +58,7 @@ class GrimityReaction extends StatelessWidget {
       children: [
         if (name != null) ...[
           Flexible(
-            child: GestureDetector(
+            child: GrimityGesture(
               onTap: onNameTap,
               child: Text(
                 name!,

--- a/lib/presentation/common/widget/grimity_selectable_image_feed.dart
+++ b/lib/presentation/common/widget/grimity_selectable_image_feed.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/feed.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_image.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/presentation/common/widget/grimity_reaction.dart';
@@ -23,7 +24,7 @@ class GrimitySelectableImageFeed extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onToggleSelected,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart
+++ b/lib/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/report.enum.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimityModalBottomSheet extends StatelessWidget {
   final List<GrimityModalButtonModel> buttons;
@@ -32,8 +33,7 @@ class GrimityModalBottomSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           ...buttons.map(
-            (button) => GestureDetector(
-              behavior: HitTestBehavior.translucent,
+            (button) => GrimityGesture(
               onTap: button.onTap,
               child: Container(
                 width: double.maxFinite,
@@ -82,7 +82,7 @@ class _BottomSheetButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.symmetric(vertical: 11, horizontal: 16),

--- a/lib/presentation/common/widget/popup/grimity_profile_link_bottom_sheet.dart
+++ b/lib/presentation/common/widget/popup/grimity_profile_link_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/link.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/profile/enum/link_type_enum.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -40,7 +41,7 @@ class GrimityProfileLinkBottomSheet extends StatelessWidget {
             children: [
               Text("프로필 링크", style: AppTypeface.subTitle3),
               const Spacer(),
-              GestureDetector(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
+              GrimityGesture(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
             ],
           ),
           Gap(24),
@@ -70,8 +71,7 @@ class _LinkItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: () async {
         if (link.linkName == '이메일') {
           await launchUrl(Uri.parse('mailto:${link.link}'));

--- a/lib/presentation/common/widget/popup/grimity_select_modal_bottom_sheet.dart
+++ b/lib/presentation/common/widget/popup/grimity_select_modal_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 /// 공통 선택 모달 바텀 시트
 class GrimitySelectModalBottomSheet extends ConsumerWidget {
@@ -71,7 +72,7 @@ class GrimitySelectModalBottomSheet extends ConsumerWidget {
             children: [
               titleNode,
               const Spacer(),
-              GestureDetector(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
+              GrimityGesture(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
             ],
           ),
           Gap(24),
@@ -94,7 +95,7 @@ class GrimitySelectModalBottomSheet extends ConsumerWidget {
           ),
           Gap(24),
           if (onSave != null) ...[
-            GestureDetector(
+            GrimityGesture(
               onTap: onSave,
               child: Container(
                 decoration: BoxDecoration(color: AppColor.primary4, borderRadius: BorderRadius.circular(10)),
@@ -150,7 +151,7 @@ class _SelectBottomSheetButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: isDisabled ? null : onTap,
       child: Container(
         height: 52,

--- a/lib/presentation/common/widget/popup/grimity_share_modal_bottom_sheet.dart
+++ b/lib/presentation/common/widget/popup/grimity_share_modal_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/util/share_util.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 enum ShareContentType { feed, post, profile }
 
@@ -82,7 +83,7 @@ class GrimityShareModalBottomSheet extends StatelessWidget {
             children: [
               Text("게시글 공유하기", style: AppTypeface.subTitle3),
               const Spacer(),
-              GestureDetector(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
+              GrimityGesture(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
             ],
           ),
           Gap(16),
@@ -152,7 +153,7 @@ class _BottomSheetButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.symmetric(vertical: 11, horizontal: 16),

--- a/lib/presentation/common/widget/system/board/grimity_post_card.dart
+++ b/lib/presentation/common/widget/system/board/grimity_post_card.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/post_type.enum.dart';
 import 'package:grimity/domain/entity/post.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_highlight_text_span.dart';
 import 'package:grimity/presentation/common/widget/grimity_reaction.dart';
 import 'package:grimity/presentation/common/widget/system/chip/grimity_chip.dart';
@@ -20,7 +21,7 @@ class GrimityPostCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () => PostDetailRoute(id: post.id).push(context),
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: 16),

--- a/lib/presentation/common/widget/system/check/grimity_check_box.dart
+++ b/lib/presentation/common/widget/system/check/grimity_check_box.dart
@@ -3,6 +3,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_animation_button.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimityCheckBox extends StatelessWidget {
   const GrimityCheckBox({super.key, required this.value, this.onChanged});
@@ -39,8 +40,7 @@ class GrimityCheckBox extends StatelessWidget {
     required String label,
     required VoidCallback onTap,
   }) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: onTap,
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -65,8 +65,7 @@ class GrimityCheckBox extends StatelessWidget {
     required VoidCallback onSelect,
     required Widget child,
   }) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: onSelect,
       child: IgnorePointer(
         ignoring: isVisible,

--- a/lib/presentation/common/widget/system/more/grimity_more_button.dart
+++ b/lib/presentation/common/widget/system/more/grimity_more_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 /// 공통 더보기 버튼
 class GrimityMoreButton extends StatelessWidget {
@@ -15,8 +16,7 @@ class GrimityMoreButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         width: 30,

--- a/lib/presentation/common/widget/system/pagination/grimity_pagination_widget.dart
+++ b/lib/presentation/common/widget/system/pagination/grimity_pagination_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 /// 페이지네이션 페이지 표시를 위한 위젯
 ///
@@ -40,7 +41,7 @@ class GrimityPaginationWidget extends StatelessWidget {
           if (currentPage > 1)
             IconButton(onPressed: () => onPageSelected(currentPage - 1), icon: Icon(Icons.chevron_left, size: 24.w)),
           ..._getPageNumbers(currentPage: currentPage, totalPages: totalPages).map(
-            (page) => GestureDetector(
+            (page) => GrimityGesture(
               onTap: () {
                 if (page != currentPage) {
                   onPageSelected(page);

--- a/lib/presentation/common/widget/system/sort/grimity_search_sort_header.dart
+++ b/lib/presentation/common/widget/system/sort/grimity_search_sort_header.dart
@@ -3,6 +3,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/sort_type.enum.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimitySearchSortHeader extends StatelessWidget {
   const GrimitySearchSortHeader({
@@ -77,8 +78,7 @@ class _ArrangeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return GrimityGesture(
       onTap: onTap,
       child: Row(
         spacing: 6,

--- a/lib/presentation/common/widget/text_field/grimity_text_field.dart
+++ b/lib/presentation/common/widget/text_field/grimity_text_field.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/grimity.enum.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class GrimityTextField extends HookWidget {
   const GrimityTextField.normal({
@@ -170,7 +171,7 @@ class GrimityTextField extends HookWidget {
       return Assets.icons.common.checkMark.svg();
     } else if (state == GrimityTextFieldState.disabled) {
       if (enabled == false) {
-        return GestureDetector(
+        return GrimityGesture(
           onTap: onEdit,
           child: Text('수정', style: AppTypeface.caption2.copyWith(color: AppColor.gray600)),
         );
@@ -179,12 +180,12 @@ class GrimityTextField extends HookWidget {
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            GestureDetector(
+            GrimityGesture(
               onTap: onCancel,
               child: Text('취소', style: AppTypeface.caption2.copyWith(color: AppColor.gray700)),
             ),
             Gap(24),
-            GestureDetector(
+            GrimityGesture(
               onTap: onSave,
               child: Text('완료', style: AppTypeface.caption2.copyWith(color: AppColor.main)),
             ),

--- a/lib/presentation/common/widget/user_card/grimity_user_card.dart
+++ b/lib/presentation/common/widget/user_card/grimity_user_card.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_button.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_gray_circle.dart';
 import 'package:grimity/presentation/common/widget/grimity_reaction.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_profile_background_image.dart';
@@ -21,7 +22,7 @@ class GrimityUserCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () => ProfileRoute(url: user.url).go(context),
       child: Container(
         decoration: BoxDecoration(

--- a/lib/presentation/drawer/widget/drawer_close_button.dart
+++ b/lib/presentation/drawer/widget/drawer_close_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class DrawerCloseButton extends StatelessWidget {
   const DrawerCloseButton({super.key});
@@ -9,7 +10,7 @@ class DrawerCloseButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Align(
       alignment: Alignment.centerRight,
-      child: GestureDetector(
+      child: GrimityGesture(
         onTap: () => Scaffold.of(context).closeEndDrawer(),
         child: Padding(
           padding: EdgeInsets.symmetric(vertical: 16.h),

--- a/lib/presentation/drawer/widget/drawer_upload_button.dart
+++ b/lib/presentation/drawer/widget/drawer_upload_button.dart
@@ -3,14 +3,14 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class DrawerUploadButton extends StatelessWidget {
   const DrawerUploadButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: () {
         Scaffold.of(context).closeEndDrawer();
         FeedUploadRoute().push(context);

--- a/lib/presentation/feed_detail/feed_detail_view.dart
+++ b/lib/presentation/feed_detail/feed_detail_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/domain/entity/feed.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/drawer/main_app_drawer.dart';
 
 class FeedDetailView extends HookWidget {
@@ -65,8 +66,7 @@ class FeedDetailView extends HookWidget {
     return Scaffold(
       endDrawer: MainAppDrawer(),
       body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
+        child: GrimityGesture(
           onTap: () => FocusScope.of(context).unfocus(),
           child: Stack(
             children: [

--- a/lib/presentation/feed_detail/view/feed_author_profile_view.dart
+++ b/lib/presentation/feed_detail/view/feed_author_profile_view.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/feed.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_image.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_image.dart';
@@ -120,7 +121,7 @@ class _AuthorFeeds extends ConsumerWidget {
           ...feeds.map(
             (feed) => Row(
               children: [
-                GestureDetector(
+                GrimityGesture(
                   onTap: () => FeedDetailRoute(id: feed.id).push(context),
                   child: AspectRatio(aspectRatio: 1.0, child: GrimityImage.small(imageUrl: feed.thumbnail ?? '')),
                 ),
@@ -130,7 +131,7 @@ class _AuthorFeeds extends ConsumerWidget {
           ),
           Padding(
             padding: EdgeInsets.symmetric(horizontal: 30),
-            child: GestureDetector(
+            child: GrimityGesture(
               onTap: () => ProfileRoute(url: url).go(context),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/presentation/feed_detail/view/feed_content_view.dart
+++ b/lib/presentation/feed_detail/view/feed_content_view.dart
@@ -13,6 +13,7 @@ import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_follow_button.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_reaction.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/more/grimity_more_button.dart';
@@ -151,7 +152,7 @@ class _FeedImageListSection extends StatelessWidget {
           itemCount: imageUrls.length,
           itemBuilder: (context, index) {
             final imageUrl = imageUrls[index];
-            return GestureDetector(
+            return GrimityGesture(
               onTap: () {
                 ImageViewerRoute(initialIndex: index, imageUrls: imageUrls).push(context);
               },

--- a/lib/presentation/feed_upload/view/feed_upload_selected_image_view.dart
+++ b/lib/presentation/feed_upload/view/feed_upload_selected_image_view.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/model/image_item_source.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/feed_upload/provider/feed_upload_provider.dart';
 import 'package:grimity/presentation/feed_upload/widget/feed_upload_add_image_button.dart';
 import 'package:grimity/presentation/photo_select/widget/photo_asset_thumbnail_widget.dart';
@@ -84,7 +85,7 @@ class _FeedUploadSelectedImage extends StatelessWidget {
         Positioned(
           left: 8,
           top: 8,
-          child: GestureDetector(
+          child: GrimityGesture(
             onTap: isThumbnail ? null : () => onThumbnailTap.call(),
             child: Container(
               padding: EdgeInsets.symmetric(vertical: 6, horizontal: 10),
@@ -112,7 +113,7 @@ class _FeedUploadSelectedImage extends StatelessWidget {
         Positioned(
           right: 8,
           top: 8,
-          child: GestureDetector(
+          child: GrimityGesture(
             onTap: () => onRemoveTap.call(),
             child: Container(
               padding: EdgeInsets.all(4),

--- a/lib/presentation/feed_upload/view/feed_upload_tag_view.dart
+++ b/lib/presentation/feed_upload/view/feed_upload_tag_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/feed_upload/provider/feed_upload_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -32,8 +33,7 @@ class FeedUploadTagView extends HookConsumerWidget {
       return () => focusNode.removeListener(listener);
     }, [focusNode]);
 
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: () {
         if (!focusNode.hasFocus) {
           focusNode.requestFocus();

--- a/lib/presentation/feed_upload/widget/feed_upload_add_image_button.dart
+++ b/lib/presentation/feed_upload/widget/feed_upload_add_image_button.dart
@@ -5,13 +5,14 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/enum/upload_image_type.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class FeedUploadAddImageButton extends StatelessWidget {
   const FeedUploadAddImageButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () => PhotoSelectRoute(type: UploadImageType.feed).push(context),
       child: Container(
         width: 160,

--- a/lib/presentation/feed_upload/widget/feed_upload_app_bar.dart
+++ b/lib/presentation/feed_upload/widget/feed_upload_app_bar.dart
@@ -8,6 +8,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/dialog/cancel_upload_dialog.dart';
 import 'package:grimity/presentation/common/provider/album_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_select_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/feed_upload/provider/feed_upload_provider.dart';
 import 'package:grimity/presentation/feed_upload/widget/feed_upload_complete_dialog.dart';
@@ -21,8 +22,7 @@ class FeedUploadAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => showCancelUploadDialog(context),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),
@@ -35,7 +35,7 @@ class FeedUploadAppBar extends StatelessWidget implements PreferredSizeWidget {
             data: (albums) {
               final selectedAlbum = albums.firstWhere((e) => e.id == ref.watch(feedUploadProvider).albumId);
 
-              return GestureDetector(
+              return GrimityGesture(
                 onTap:
                     () => GrimitySelectModalBottomSheet.show(
                       context,

--- a/lib/presentation/feed_upload/widget/feed_upload_complete_dialog.dart
+++ b/lib/presentation/feed_upload/widget/feed_upload_complete_dialog.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/service/toast_service.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/alert/grimity_dialog.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 void showUploadCompleteDialog(BuildContext context, String link) {
   showDialog(
@@ -22,7 +23,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
             context.pop();
             context.pop();
           },
-          linkWidget: GestureDetector(
+          linkWidget: GrimityGesture(
             onTap: () {
               Clipboard.setData(ClipboardData(text: link));
               ToastService.show('링크가 복사되었어요');
@@ -48,7 +49,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
             spacing: 6,
             children: [
               Expanded(
-                child: GestureDetector(
+                child: GrimityGesture(
                   onTap: () {
                     /// TODO X 공유
                   },
@@ -71,7 +72,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
                 ),
               ),
               Expanded(
-                child: GestureDetector(
+                child: GrimityGesture(
                   onTap: () {
                     /// TODO 카카오톡 공유
                   },

--- a/lib/presentation/following_feed/widget/following_feed_card.dart
+++ b/lib/presentation/following_feed/widget/following_feed_card.dart
@@ -13,6 +13,7 @@ import 'package:grimity/domain/entity/feed.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_animation_button.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_gray_circle.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/more/grimity_more_button.dart';
@@ -171,7 +172,7 @@ class _FollowingFeedCardImageCarousel extends StatelessWidget {
         final imageUrl = imageList[index];
         return Container(
           padding: EdgeInsets.only(left: index == 0 ? 16 : 4, right: index == imageList.length - 1 ? 16 : 4),
-          child: GestureDetector(
+          child: GrimityGesture(
             onTap: () {
               ImageViewerRoute(initialIndex: index, imageUrls: imageList).push(context);
             },

--- a/lib/presentation/home/view/home_feed_ranking_view.dart
+++ b/lib/presentation/home/view/home_feed_ranking_view.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/feed.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_image_feed.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/home/provider/home_data_provider.dart';
@@ -26,7 +27,7 @@ class HomeFeedRankingView extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text('주간 랭킹', style: AppTypeface.subTitle1),
-              GestureDetector(
+              GrimityGesture(
                 onTap: () => RankingRoute().go(context),
                 child: Text('더보기', style: AppTypeface.caption1.copyWith(color: AppColor.gray600)),
               ),

--- a/lib/presentation/home/view/home_latest_post_view.dart
+++ b/lib/presentation/home/view/home_latest_post_view.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/post.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/common/widget/system/board/grimity_post_feed.dart';
 import 'package:grimity/presentation/home/provider/home_data_provider.dart';
@@ -24,7 +25,7 @@ class HomeLatestPostView extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text('자유게시판 최신 글', style: AppTypeface.subTitle1),
-              GestureDetector(
+              GrimityGesture(
                 onTap: () => BoardRoute().go(context),
                 child: Text('더보기', style: AppTypeface.caption1.copyWith(color: AppColor.gray600)),
               ),

--- a/lib/presentation/home/view/home_notice_view.dart
+++ b/lib/presentation/home/view/home_notice_view.dart
@@ -3,6 +3,7 @@ import 'package:grimity/app/config/app_const.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/extension/image_extension.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class HomeNoticeView extends StatelessWidget {
   const HomeNoticeView({super.key});
@@ -11,7 +12,7 @@ class HomeNoticeView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16),
-      child: GestureDetector(
+      child: GrimityGesture(
         onTap: () => PostDetailRoute(id: AppConst.usageGuidePostId).push(context),
         child: Assets.images.noticeBanner.image(cacheWidth: 343.cacheSize(context), cacheHeight: 80.cacheSize(context)),
       ),

--- a/lib/presentation/image/image_viewer_page.dart
+++ b/lib/presentation/image/image_viewer_page.dart
@@ -8,6 +8,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:photo_view/photo_view.dart';
 
 class ImageViewerPage extends HookWidget {
@@ -25,8 +26,7 @@ class ImageViewerPage extends HookWidget {
       backgroundColor: Colors.black,
       appBar: AppBar(
         backgroundColor: Colors.black,
-        leading: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        leading: GrimityGesture(
           onTap: () => context.pop(),
           child: Padding(
             padding: EdgeInsets.symmetric(vertical: 12.h, horizontal: 16.w),
@@ -70,7 +70,7 @@ class ImageViewerPage extends HookWidget {
                   itemCount: imageUrls.length,
                   itemBuilder: (context, index) {
                     final isSelected = index == currentIndex.value;
-                    return GestureDetector(
+                    return GrimityGesture(
                       onTap: () => pageController.jumpToPage(index),
                       child: Container(
                         decoration: BoxDecoration(

--- a/lib/presentation/main/widget/main_floating_action_button.dart
+++ b/lib/presentation/main/widget/main_floating_action_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 
 class MainFloatingActionButton extends StatelessWidget {
@@ -14,7 +15,7 @@ class MainFloatingActionButton extends StatelessWidget {
     final assetImage =
         currentIndex == MainNavigationItem.board.index ? Assets.icons.main.addPost : Assets.icons.main.add;
 
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () {
         if (currentIndex == MainNavigationItem.board.index) {
           PostUploadRoute().push(context);

--- a/lib/presentation/notification/widget/notification_action_button.dart
+++ b/lib/presentation/notification/widget/notification_action_button.dart
@@ -3,6 +3,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class NotificationActionButton extends StatelessWidget {
   const NotificationActionButton({super.key, required this.title, required this.onTap, required this.icon});
@@ -13,7 +14,7 @@ class NotificationActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onTap,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/presentation/notification/widget/notification_app_bar.dart
+++ b/lib/presentation/notification/widget/notification_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget {
   const NotificationAppBar({super.key});
@@ -16,7 +17,7 @@ class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget 
       title: Text('알림', style: AppTypeface.subTitle3),
       titleSpacing: 0,
       actions: [
-        GestureDetector(
+        GrimityGesture(
           onTap: () => SettingRoute().push(context),
           child: Assets.icons.common.setting.svg(width: 24.w, height: 24.w),
         ),

--- a/lib/presentation/notification/widget/notification_widget.dart
+++ b/lib/presentation/notification/widget/notification_widget.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_profile.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/domain/entity/notification.dart';
@@ -46,7 +47,7 @@ class NotificationWidget extends ConsumerWidget {
               ),
             ),
             Gap(8),
-            GestureDetector(
+            GrimityGesture(
               onTap: () => notifier.deleteNotification(notification.id),
               child: Assets.icons.common.close.svg(
                 width: 20,

--- a/lib/presentation/photo_select/view/photo_selectable_image_view.dart
+++ b/lib/presentation/photo_select/view/photo_selectable_image_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/presentation/common/model/image_item_source.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/photo_select/provider/photo_select_provider.dart';
 import 'package:grimity/presentation/photo_select/widget/photo_asset_thumbnail_widget.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -43,7 +44,7 @@ class _PhotoSelectableImageThumbnail extends ConsumerWidget with PhotoSelectMixi
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () => photoNotifier(ref).toggleImageSelection(ImageSourceItem.asset(asset)),
       child: Stack(
         children: [

--- a/lib/presentation/photo_select/view/photo_selected_image_view.dart
+++ b/lib/presentation/photo_select/view/photo_selected_image_view.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/model/image_item_source.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/photo_select/provider/photo_select_provider.dart';
 import 'package:grimity/presentation/photo_select/widget/photo_asset_thumbnail_widget.dart';
 
@@ -65,8 +66,7 @@ class _PhotoSelectedImageThumbnail extends ConsumerWidget with PhotoSelectMixin 
             Positioned(
               top: -8,
               right: -8,
-              child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
+              child: GrimityGesture(
                 onTap: () => photoNotifier(ref).removeSelectedImage(imageSource),
                 child: Container(
                   decoration: BoxDecoration(

--- a/lib/presentation/photo_select/widget/photo_permission_request_banner.dart
+++ b/lib/presentation/photo_select/widget/photo_permission_request_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 class PermissionRequestBanner extends StatelessWidget {
@@ -18,7 +19,7 @@ class PermissionRequestBanner extends StatelessWidget {
             '권한 설정에서 모든 사진 접근 권한을 허용하면 더 많은 그림을 선택해 업로드 할 수 있어요',
             style: AppTypeface.label3.copyWith(color: AppColor.gray600),
           ),
-          GestureDetector(
+          GrimityGesture(
             onTap: () => PhotoManager.openSetting(),
             child: Row(
               children: [

--- a/lib/presentation/photo_select/widget/photo_select_app_bar.dart
+++ b/lib/presentation/photo_select/widget/photo_select_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/photo_select/provider/photo_select_provider.dart';
 
 class PhotoSelectAppBar extends ConsumerWidget with PhotoSelectMixin implements PreferredSizeWidget {
@@ -23,8 +24,7 @@ class PhotoSelectAppBar extends ConsumerWidget with PhotoSelectMixin implements 
         return AppBar(
           toolbarHeight: AppTheme.kToolbarHeight.height,
           leading: Center(
-            child: GestureDetector(
-              behavior: HitTestBehavior.translucent,
+            child: GrimityGesture(
               onTap: () => context.pop(),
               child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
             ),
@@ -62,8 +62,7 @@ class PhotoSelectAppBar extends ConsumerWidget with PhotoSelectMixin implements 
   _buildCloseAppBar(BuildContext context) => AppBar(
     toolbarHeight: AppTheme.kToolbarHeight.height,
     leading: Center(
-      child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
+      child: GrimityGesture(
         onTap: () => context.pop(),
         child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
       ),

--- a/lib/presentation/post_detail/post_detail_view.dart
+++ b/lib/presentation/post_detail/post_detail_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/domain/entity/post.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/drawer/main_app_drawer.dart';
 import 'package:grimity/presentation/post_detail/view/post_latest_view.dart';
 
@@ -62,8 +63,7 @@ class PostDetailView extends HookWidget {
     return Scaffold(
       endDrawer: MainAppDrawer(),
       body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
+        child: GrimityGesture(
           onTap: () => FocusScope.of(context).unfocus(),
           child: Stack(
             children: [

--- a/lib/presentation/post_upload/widget/post_add_link_bottom_sheet.dart
+++ b/lib/presentation/post_upload/widget/post_add_link_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 
 class PostAddLinkBottomSheet extends HookWidget {
@@ -58,7 +59,7 @@ class PostAddLinkBottomSheet extends HookWidget {
             children: [
               Text('링크 추가', style: AppTypeface.subTitle3),
               const Spacer(),
-              GestureDetector(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
+              GrimityGesture(onTap: () => context.pop(), child: Assets.icons.common.close.svg(width: 24, height: 24)),
             ],
           ),
           Gap(24),
@@ -77,8 +78,7 @@ class PostAddLinkBottomSheet extends HookWidget {
             ),
           ),
           Gap(24),
-          GestureDetector(
-            behavior: HitTestBehavior.translucent,
+          GrimityGesture(
             onTap: () {
               final text = textController.value.text.trim();
               final url = _normalizeUrl(urlController.value.text);

--- a/lib/presentation/post_upload/widget/post_upload_app_bar.dart
+++ b/lib/presentation/post_upload/widget/post_upload_app_bar.dart
@@ -8,6 +8,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/post_type.enum.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/dialog/cancel_upload_dialog.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_select_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/post_upload/provider/post_upload_page_argument_provider.dart';
 import 'package:grimity/presentation/post_upload/provider/post_upload_provider.dart';
@@ -21,8 +22,7 @@ class PostUploadAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => showCancelUploadDialog(context),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),
@@ -31,7 +31,7 @@ class PostUploadAppBar extends StatelessWidget implements PreferredSizeWidget {
         builder: (context, ref, child) {
           final type = ref.watch(postUploadProvider).type;
 
-          return GestureDetector(
+          return GrimityGesture(
             onTap: () {
               GrimitySelectModalBottomSheet.show(
                 context,

--- a/lib/presentation/post_upload/widget/post_upload_complete_dialog.dart
+++ b/lib/presentation/post_upload/widget/post_upload_complete_dialog.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/service/toast_service.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/alert/grimity_dialog.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 void showUploadCompleteDialog(BuildContext context, String link) {
   showDialog(
@@ -22,7 +23,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
             context.pop();
             context.pop();
           },
-          linkWidget: GestureDetector(
+          linkWidget: GrimityGesture(
             onTap: () {
               Clipboard.setData(ClipboardData(text: link));
               ToastService.show('링크가 복사되었어요');
@@ -48,7 +49,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
             spacing: 6,
             children: [
               Expanded(
-                child: GestureDetector(
+                child: GrimityGesture(
                   onTap: () {
                     /// TODO X 공유
                   },
@@ -71,7 +72,7 @@ void showUploadCompleteDialog(BuildContext context, String link) {
                 ),
               ),
               Expanded(
-                child: GestureDetector(
+                child: GrimityGesture(
                   onTap: () {
                     /// TODO 카카오톡 공유
                   },

--- a/lib/presentation/post_upload/widget/post_upload_deletable_image_builder.dart
+++ b/lib/presentation/post_upload/widget/post_upload_deletable_image_builder.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grimity/presentation/common/widget/grimity_cached_network_image.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/check/grimity_check_box.dart';
 import 'package:grimity/presentation/post_upload/provider/post_upload_provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -45,10 +46,10 @@ class DeletableImageBuilder extends EmbedBuilder {
         final selected = state.selectedImageUrls.contains(imageUrl);
 
         if (!imageEdit) {
-          return GestureDetector(onTap: () => notifier.updateImageEdit(true), child: child);
+          return GrimityGesture(onTap: () => notifier.updateImageEdit(true), child: child);
         }
 
-        return GestureDetector(
+        return GrimityGesture(
           onTap: () => notifier.toggleSelectedImageUrl(imageUrl),
           child: Stack(
             children: [

--- a/lib/presentation/post_upload/widget/toolbar/image_delete_toolbar.dart
+++ b/lib/presentation/post_upload/widget/toolbar/image_delete_toolbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/post_upload/provider/post_upload_page_argument_provider.dart';
 import 'package:grimity/presentation/post_upload/provider/post_upload_provider.dart';
 
@@ -24,11 +25,11 @@ class ImageDeleteToolbar extends ConsumerWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          GestureDetector(
+          GrimityGesture(
             onTap: () => notifier.updateImageEdit(false),
             child: Text('취소', style: AppTypeface.label3.copyWith(color: AppColor.gray700)),
           ),
-          GestureDetector(
+          GrimityGesture(
             onTap:
                 deletable
                     ? null

--- a/lib/presentation/post_upload/widget/toolbar/parts/color_menu.dart
+++ b/lib/presentation/post_upload/widget/toolbar/parts/color_menu.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/util/color_util.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/post_upload/widget/toolbar/parts/menu_archor_square.dart';
 import 'package:grimity/presentation/post_upload/widget/toolbar/parts/quill_toolbar_utils.dart';
 import 'package:grimity/gen/assets.gen.dart';
@@ -87,7 +88,7 @@ class ColorMenu extends HookWidget {
                   _colors.map((c) {
                     final isSelected = c.equalsHexCode(color);
 
-                    return GestureDetector(
+                    return GrimityGesture(
                       onTap: () {
                         final hex = c.toHexColor();
 

--- a/lib/presentation/profile/view/profile_feed_tab_view.dart
+++ b/lib/presentation/profile/view/profile_feed_tab_view.dart
@@ -11,6 +11,7 @@ import 'package:grimity/domain/entity/feed.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_feed_grid.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/common/widget/system/sort/grimity_search_sort_header.dart';
 import 'package:grimity/presentation/profile/enum/profile_view_type_enum.dart';
@@ -87,7 +88,7 @@ class ProfileFeedTabView extends HookConsumerWidget {
   }
 
   Widget _buildAlbumEdit(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap:
           () => AlbumEditRoute(user.albums ?? <Album>[]).push(context).then((_) => ref.invalidate(profileDataProvider)),
       child: Container(

--- a/lib/presentation/profile/view/user_profile_view.dart
+++ b/lib/presentation/profile/view/user_profile_view.dart
@@ -16,6 +16,7 @@ import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
 import 'package:grimity/presentation/common/widget/alert/grimity_dialog.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_follow_button.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/more/grimity_more_button.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_share_modal_bottom_sheet.dart';
@@ -68,7 +69,7 @@ class UserProfileView extends ConsumerWidget {
       left: 53,
       child: Align(
         alignment: Alignment.topLeft,
-        child: GestureDetector(
+        child: GrimityGesture(
           onTap: () => context.push(ProfileEditRoute.path, extra: user),
           child: Container(
             width: 26,
@@ -194,7 +195,7 @@ class _UserProfile extends StatelessWidget {
   }
 
   Widget _buildUserFollowerCount(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: viewType == ProfileViewType.mine ? () => FollowRoute().push(context) : null,
       child: Row(
         children: [
@@ -245,8 +246,7 @@ class _UserProfile extends StatelessWidget {
 
           return Padding(
             padding: EdgeInsets.only(bottom: index < 2 ? 6 : 0),
-            child: GestureDetector(
-              behavior: HitTestBehavior.translucent,
+            child: GrimityGesture(
               onTap: () async => await launchUrl(Uri.parse(e.link)),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
@@ -266,7 +266,7 @@ class _UserProfile extends StatelessWidget {
                         ),
                         if (index == 2 && user.links!.length > 3) ...[
                           Gap(12),
-                          GestureDetector(
+                          GrimityGesture(
                             onTap: () => showProfileLinkBottomSheet(context, user.links!),
                             child: Text(
                               '외 링크 ${user.links!.length - 3}개',

--- a/lib/presentation/profile/widget/album_chip.dart
+++ b/lib/presentation/profile/widget/album_chip.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class AlbumChip extends StatelessWidget {
   const AlbumChip({super.key, required this.title, this.amount, required this.onTap, this.isSelected = false});
@@ -15,8 +16,7 @@ class AlbumChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 8.w),

--- a/lib/presentation/profile_edit/view/profile_crop_image_view.dart
+++ b/lib/presentation/profile_edit/view/profile_crop_image_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ProfileCropImageView extends HookConsumerWidget {
@@ -18,7 +19,7 @@ class ProfileCropImageView extends HookConsumerWidget {
       appBar: AppBar(
         backgroundColor: Colors.black,
         leading: Center(
-          child: GestureDetector(
+          child: GrimityGesture(
             onTap: () => context.pop(),
             child: Assets.icons.profileEdit.arrowLeft.svg(width: 24, height: 24),
           ),

--- a/lib/presentation/profile_edit/widget/profile_edit_app_bar.dart
+++ b/lib/presentation/profile_edit/widget/profile_edit_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/profile_edit/provider/profile_edit_provider.dart';
 import 'package:grimity/presentation/profile_edit/widget/profile_edit_cancel_dialog.dart';
 
@@ -18,8 +19,7 @@ class ProfileEditAppBar extends ConsumerWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () {
             if (state.isSaved) {
               context.pop();

--- a/lib/presentation/profile_edit/widget/profile_edit_background.dart
+++ b/lib/presentation/profile_edit/widget/profile_edit_background.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/presentation/common/enum/upload_image_type.dart';
 import 'package:grimity/presentation/common/widget/grimity_circular_progress_indicator.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_profile_background_image.dart';
 import 'package:grimity/presentation/profile_edit/provider/profile_edit_provider.dart';
@@ -44,7 +45,7 @@ class _ProfileEditBackgroundEditButton extends ConsumerWidget {
       bottom: 16,
       child: Align(
         alignment: Alignment.bottomRight,
-        child: GestureDetector(
+        child: GrimityGesture(
           onTap: isUploading ? null : () => _showBackgroundImageBottomSheet(context, ref),
           child: Container(
             width: 69.w,

--- a/lib/presentation/profile_edit/widget/profile_edit_link.dart
+++ b/lib/presentation/profile_edit/widget/profile_edit_link.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/link.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_select_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 import 'package:grimity/presentation/profile/enum/link_type_enum.dart';
@@ -29,8 +30,7 @@ class ProfileEditLink extends HookConsumerWidget {
           children: [
             Text("외부 링크", style: AppTypeface.caption1),
             const Spacer(),
-            GestureDetector(
-              behavior: HitTestBehavior.translucent,
+            GrimityGesture(
               onTap: () => profileEditNotifier.toggleLinkEditing(),
               child: Text(
                 profileEdit.isLinkEditing ? "완료" : "순서 편집",
@@ -76,7 +76,7 @@ class ProfileEditLink extends HookConsumerWidget {
           },
         ),
         Gap(10),
-        GestureDetector(
+        GrimityGesture(
           onTap:
               () => GrimitySelectModalBottomSheet.show(
                 context,
@@ -215,7 +215,7 @@ class LinkWidget extends HookConsumerWidget {
               child: Assets.icons.profileEdit.dragAndDrop.svg(width: 20, height: 20),
             ),
           ] else ...[
-            GestureDetector(
+            GrimityGesture(
               onTap: () => profileEditNotifier.deleteLink(link),
               child: Assets.icons.profileEdit.delete.svg(width: 20, height: 20),
             ),

--- a/lib/presentation/profile_edit/widget/profile_edit_profile_image.dart
+++ b/lib/presentation/profile_edit/widget/profile_edit_profile_image.dart
@@ -4,6 +4,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/enum/upload_image_type.dart';
 import 'package:grimity/presentation/common/widget/grimity_circular_progress_indicator.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/popup/grimity_modal_bottom_sheet.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_profile_image.dart';
 import 'package:grimity/presentation/profile_edit/provider/upload_image_provider.dart';
@@ -21,8 +22,7 @@ class ProfileEditProfileImage extends ConsumerWidget {
       top: -40,
       child: Align(
         alignment: Alignment.topLeft,
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: isUploading ? null : () => _showProfileImageBottomSheet(context, ref),
           child: Stack(
             children: [

--- a/lib/presentation/ranking/view/popular_feed_view.dart
+++ b/lib/presentation/ranking/view/popular_feed_view.dart
@@ -8,6 +8,7 @@ import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/domain/entity/feed.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_feed_grid.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/ranking/provider/popluar_feed_data_provider.dart';
 import 'package:grimity/presentation/ranking/provider/popular_feed_ranking_option_provider.dart';
@@ -36,7 +37,7 @@ class PopularFeedView extends ConsumerWidget {
             children:
                 FeedRankingType.values
                     .map(
-                      (type) => GestureDetector(
+                      (type) => GrimityGesture(
                         onTap: () => ref.read(popularFeedRankingOptionProvider.notifier).setType(type),
                         child: Container(
                           padding: EdgeInsets.symmetric(vertical: 8, horizontal: 14),
@@ -75,7 +76,7 @@ class PopularFeedView extends ConsumerWidget {
                           '${option.baseDate.oneWeekBeforeFormatted} - ${option.baseDate.isSameDay(DateTime.now()) ? '오늘' : option.baseDate.toYearMonthDay}',
                           style: AppTypeface.label2.copyWith(color: AppColor.gray700),
                         )
-                        : GestureDetector(
+                        : GrimityGesture(
                           onTap: () => MonthPickerBottomSheet.show(context, option.baseDate),
                           child: Row(
                             spacing: 6,
@@ -96,7 +97,7 @@ class PopularFeedView extends ConsumerWidget {
                 Row(
                   spacing: 12,
                   children: [
-                    GestureDetector(
+                    GrimityGesture(
                       onTap:
                           option.isPreviousAvailable
                               ? () => ref.read(popularFeedRankingOptionProvider.notifier).goToPrevious()
@@ -115,7 +116,7 @@ class PopularFeedView extends ConsumerWidget {
                         ),
                       ),
                     ),
-                    GestureDetector(
+                    GrimityGesture(
                       onTap:
                           option.isNextAvailable
                               ? () => ref.read(popularFeedRankingOptionProvider.notifier).goToNext()

--- a/lib/presentation/ranking/view/popular_tag_view.dart
+++ b/lib/presentation/ranking/view/popular_tag_view.dart
@@ -5,6 +5,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/domain/entity/tag.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_image.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/ranking/provider/popular_tag_data_provider.dart';
@@ -66,7 +67,7 @@ class _PopularTagCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: () {
         // TODO 태그 검색
       },

--- a/lib/presentation/ranking/widget/month_picker_bottom_sheet.dart
+++ b/lib/presentation/ranking/widget/month_picker_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/ranking/provider/popular_feed_ranking_option_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -46,13 +47,13 @@ class MonthPickerBottomSheet extends HookConsumerWidget {
             Gap(24),
             Row(
               children: [
-                GestureDetector(onTap: () => selectedYear.value--, child: Icon(Icons.chevron_left, size: 26)),
+                GrimityGesture(onTap: () => selectedYear.value--, child: Icon(Icons.chevron_left, size: 26)),
                 Gap(20),
                 Text('${selectedYear.value}', style: AppTypeface.subTitle3.copyWith(color: AppColor.gray800)),
                 Gap(20),
-                GestureDetector(onTap: () => selectedYear.value++, child: Icon(Icons.chevron_right, size: 26)),
+                GrimityGesture(onTap: () => selectedYear.value++, child: Icon(Icons.chevron_right, size: 26)),
                 const Spacer(),
-                GestureDetector(
+                GrimityGesture(
                   onTap: () => context.pop(),
                   child: Assets.icons.common.close.svg(width: 24, height: 24),
                 ),
@@ -103,7 +104,7 @@ class _MonthButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap:
           isDisabled
               ? null

--- a/lib/presentation/report/view/report_body_view.dart
+++ b/lib/presentation/report/view/report_body_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 import 'package:grimity/presentation/common/widget/system/check/grimity_radio_button.dart';
 import 'package:grimity/presentation/report/provider/report_provider.dart';
@@ -97,7 +98,7 @@ class _ReportReasonTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return GrimityGesture(
       onTap: onTap,
       child: Row(
         spacing: 12,

--- a/lib/presentation/report/widget/report_app_bar.dart
+++ b/lib/presentation/report/widget/report_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class ReportAppBar extends StatelessWidget implements PreferredSizeWidget {
   const ReportAppBar({super.key});
@@ -14,8 +15,7 @@ class ReportAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => context.pop(),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:grimity/app/service/toast_service.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/text_field/grimity_text_field.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
@@ -28,7 +29,7 @@ class _SearchAppBarDelegate extends SliverPersistentHeaderDelegate {
       alignment: Alignment.centerLeft,
       child: Row(
         children: [
-          GestureDetector(
+          GrimityGesture(
             onTap: () => Navigator.of(context).maybePop(),
             child: Icon(Icons.arrow_back_ios_new_outlined, size: 24.w),
           ),

--- a/lib/presentation/setting/widget/setting_footer.dart
+++ b/lib/presentation/setting/widget/setting_footer.dart
@@ -7,6 +7,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/login_provider.enum.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/grimity_gray_circle.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -27,14 +28,14 @@ class SettingFooter extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  GestureDetector(
+                  GrimityGesture(
                     onTap: () async {
                       await launchUrl(Uri.parse(AppConst.privacyPolicyUrl));
                     },
                     child: Text('개인정보취급방침', style: AppTypeface.caption2.copyWith(color: AppColor.gray500)),
                   ),
                   GrimityGrayCircle(),
-                  GestureDetector(
+                  GrimityGesture(
                     onTap: () async {
                       await launchUrl(Uri.parse(AppConst.serviceTermsUrl));
                     },

--- a/lib/presentation/sign_in/widget/sso_buttons.dart
+++ b/lib/presentation/sign_in/widget/sso_buttons.dart
@@ -4,6 +4,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class AppleSSOButton extends StatelessWidget {
   const AppleSSOButton({super.key, required this.onTap});
@@ -48,8 +49,7 @@ class _SSOButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
+    return GrimityGesture(
       onTap: onTap,
       child: Container(
         width: 283,

--- a/lib/presentation/sign_up/widget/sign_up_app_bar.dart
+++ b/lib/presentation/sign_up/widget/sign_up_app_bar.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class SignUpAppBar extends StatelessWidget implements PreferredSizeWidget {
   const SignUpAppBar({super.key});
@@ -13,8 +14,7 @@ class SignUpAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       toolbarHeight: AppTheme.kToolbarHeight.height,
       leading: Center(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
+        child: GrimityGesture(
           onTap: () => context.pop(),
           child: Assets.icons.common.close.svg(width: 24.w, height: 24.w),
         ),

--- a/lib/presentation/sign_up/widget/sign_up_term_agree_widget.dart
+++ b/lib/presentation/sign_up/widget/sign_up_term_agree_widget.dart
@@ -4,6 +4,7 @@ import 'package:gap/gap.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_const.dart';
 import 'package:grimity/app/config/app_typeface.dart';
+import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/check/grimity_check_box.dart';
 import 'package:grimity/presentation/sign_up/provider/sign_up_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -24,7 +25,7 @@ class SignUpTermAgreeWidget extends ConsumerWidget {
         const Gap(8),
         Row(
           children: [
-            GestureDetector(
+            GrimityGesture(
               onTap: () async {
                 await launchUrl(Uri.parse(AppConst.serviceTermsUrl));
               },
@@ -34,7 +35,7 @@ class SignUpTermAgreeWidget extends ConsumerWidget {
               ),
             ),
             Text(' 과 ', style: AppTypeface.caption1.copyWith(color: AppColor.gray600)),
-            GestureDetector(
+            GrimityGesture(
               onTap: () async {
                 await launchUrl(Uri.parse(AppConst.privacyPolicyUrl));
               },


### PR DESCRIPTION
- 빈 영역 클릭 시에는 클릭이 감지되지 않은 문제를 해결.

### 간단한 설명
기존 HitTestBehavior.translucent는 자식에게 먼저 제스처 처리를 맡기기 때문에 빈 영역에서는 터치가 감지가 안됩니다용. 그래서 HitTestBehavior.opaque를 사용하도록 하여 위젯 전체 영역에서 제스처를 처리하도록 보장하고, 이걸 깔끔하게 캡슐화하기 위해 GrimityGesture 위젯을 새로 만들어서 사용하도록 수정했습니다용.
