### PR TITLE
feat: 팔로잉 피드 각 영역 터치 시 이동 로직 추가

### DIFF
--- a/lib/presentation/following_feed/widget/following_feed_card.dart
+++ b/lib/presentation/following_feed/widget/following_feed_card.dart
@@ -80,19 +80,20 @@ class FollowingFeedCard extends ConsumerWidget {
                 Gap(8),
                 GrimityGesture(
                   onTap: () => _pushFeedDetail(context, feed.id),
-                  child: Text(feed.title, style: AppTypeface.subTitle4.copyWith(color: AppColor.gray800)),
-                ),
-                Gap(6),
-                GrimityGesture(
-                  onTap: () => _pushFeedDetail(context, feed.id),
-                  child: ReadMoreText(
-                    feed.content ?? '',
-                    style: AppTypeface.label3.copyWith(color: AppColor.gray800),
-                    trimMode: TrimMode.Line,
-                    trimLines: 3,
-                    trimExpandedText: '',
-                    trimCollapsedText: '더보기',
-                    moreStyle: AppTypeface.label2.copyWith(color: AppColor.main),
+                  child: Column(
+                    children: [
+                      Text(feed.title, style: AppTypeface.subTitle4.copyWith(color: AppColor.gray800)),
+                      Gap(6),
+                      ReadMoreText(
+                        feed.content ?? '',
+                        style: AppTypeface.label3.copyWith(color: AppColor.gray800),
+                        trimMode: TrimMode.Line,
+                        trimLines: 3,
+                        trimExpandedText: '',
+                        trimCollapsedText: '더보기',
+                        moreStyle: AppTypeface.label2.copyWith(color: AppColor.main),
+                      ),
+                    ],
                   ),
                 ),
               ],


### PR DESCRIPTION
https://github.com/Grimity/grimity-flutter/issues/99 이슈에 대한 PR 입니다.

프로필 영역 터치 시  해당 작성자의 프로필 화면으로 이동하도록 했고 제목, 내용, 댓글 영역 터치 시 피드 상세 화면으로 이동하도록 구현하였습니다.