### PR TITLE
fix: 프로필 이름 Opacity 계산 로직 개선

### DIFF
--- a/lib/presentation/profile/profile_view.dart
+++ b/lib/presentation/profile/profile_view.dart
@@ -31,103 +31,89 @@ class ProfileView extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nameOpacity = useState(0.0);
-    final userProfileKey = useMemoized(() => GlobalKey());
     final tabController = useTabController(initialLength: postTabView == null ? 1 : 2);
 
     return Scaffold(
       body: SafeArea(
-        child: NotificationListener<ScrollNotification>(
-          onNotification: (scrollNotification) {
-            if (scrollNotification is ScrollUpdateNotification) {
-              final RenderBox? renderBox = userProfileKey.currentContext?.findRenderObject() as RenderBox?;
-              final double offset = scrollNotification.metrics.pixels;
+        child: AppBarConnection(
+          appBars: [
+            AppBar(
+              behavior: AbsoluteAppBarBehavior(),
+              body: ProfileAppBar(userName: user.name, nameOpacity: nameOpacity.value, viewType: viewType),
+            ),
+            AppBar.builder(
+              behavior: MaterialAppBarBehavior(alignAnimation: false),
+              builder: (context, position) {
+                // AppBar 스크롤 진행도(0.0 ~ 1.0)
+                final offset = position.offset;
 
-              if (renderBox != null) {
-                final profileHeight = renderBox.size.height;
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  const fadeStartOffset = 0.6;
+                  const fadeEndOffset = 0.8;
 
-                final double fadeStartOffset = profileHeight * 0.6;
-                final double fadeEndOffset = profileHeight * 0.8;
-
-                if (offset <= fadeStartOffset) {
-                  nameOpacity.value = 0.0;
-                } else if (offset >= fadeEndOffset) {
-                  nameOpacity.value = 1.0;
-                } else {
-                  nameOpacity.value = (offset - fadeStartOffset) / (fadeEndOffset - fadeStartOffset);
-                }
-              } else {
-                const double fadeStartOffset = 150.0;
-                const double fadeEndOffset = 250.0;
-
-                if (offset <= fadeStartOffset) {
-                  nameOpacity.value = 0.0;
-                } else if (offset >= fadeEndOffset) {
-                  nameOpacity.value = 1.0;
-                } else {
-                  nameOpacity.value = (offset - fadeStartOffset) / (fadeEndOffset - fadeStartOffset);
-                }
-              }
-            }
-            return false;
-          },
-          child: AppBarConnection(
-            appBars: [
-              AppBar(
-                behavior: AbsoluteAppBarBehavior(),
-                body: ProfileAppBar(userName: user.name, nameOpacity: nameOpacity.value, viewType: viewType),
+                  // 0.6 이하인 경우 이름 미표시
+                  if (offset <= fadeStartOffset) {
+                    nameOpacity.value = 0.0;
+                  }
+                  // 0.8 이상인 경우는 이름 표시
+                  else if (offset >= fadeEndOffset) {
+                    nameOpacity.value = 1.0;
+                  }
+                  // 0.6 ~ 0.8 사이 구간은 fade 처리
+                  else {
+                    nameOpacity.value = (offset - fadeStartOffset) / (fadeEndOffset - fadeStartOffset);
+                  }
+                });
+                return userProfileView;
+              },
+            ),
+            AppBar(
+              behavior: AbsoluteAppBarBehavior(),
+              body: ProfileTabBar(user: user, tabController: tabController, viewType: viewType),
+            ),
+          ],
+          child: TabBarView(
+            controller: tabController,
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              // pull to refresh 를 프로필 전체 기준으로 하려고 했으나
+              // 구조상 하나의 스크롤로 잡기가 어려워 탭 View 기준으로 refresh 처리
+              // refresh시 해당 탭 + 사용자 정보까지 업데이트 처리
+              GrimityRefreshIndicator(
+                onRefresh: () async {
+                  await Future.wait([
+                    ref.refresh(profileFeedsDataProvider(user.id).future),
+                    ref.refresh(profileDataProvider(user.url).future),
+                  ]);
+                },
+                child: GrimityInfiniteScrollPagination(
+                  isEnabled:
+                      user.id.isNotEmpty &&
+                      ref.watch(profileFeedsDataProvider(user.id)).valueOrNull?.nextCursor != null,
+                  onLoadMore: () => ref.read(profileFeedsDataProvider(user.id).notifier).loadMore(user.id),
+                  child: feedTabView,
+                ),
               ),
-              AppBar(
-                behavior: MaterialAppBarBehavior(alignAnimation: false),
-                body: Container(key: userProfileKey, child: userProfileView),
-              ),
-              AppBar(
-                behavior: AbsoluteAppBarBehavior(),
-                body: ProfileTabBar(user: user, tabController: tabController, viewType: viewType),
-              ),
-            ],
-            child: TabBarView(
-              controller: tabController,
-              physics: const NeverScrollableScrollPhysics(),
-              children: [
-                // pull to refresh 를 프로필 전체 기준으로 하려고 했으나
-                // 구조상 하나의 스크롤로 잡기가 어려워 탭 View 기준으로 refresh 처리
-                // refresh시 해당 탭 + 사용자 정보까지 업데이트 처리
+
+              if (postTabView != null)
                 GrimityRefreshIndicator(
                   onRefresh: () async {
                     await Future.wait([
-                      ref.refresh(profileFeedsDataProvider(user.id).future),
+                      ref.refresh(profilePostsDataProvider(user.id).future),
                       ref.refresh(profileDataProvider(user.url).future),
                     ]);
                   },
                   child: GrimityInfiniteScrollPagination(
                     isEnabled:
-                        user.id.isNotEmpty &&
-                        ref.watch(profileFeedsDataProvider(user.id)).valueOrNull?.nextCursor != null,
-                    onLoadMore: () => ref.read(profileFeedsDataProvider(user.id).notifier).loadMore(user.id),
-                    child: feedTabView,
+                        (() {
+                          final posts = ref.watch(profilePostsDataProvider(user.id)).valueOrNull;
+                          return user.id.isNotEmpty && posts != null && posts.length % 10 == 0;
+                        })(),
+                    onLoadMore: () => ref.read(profilePostsDataProvider(user.id).notifier).loadMore(user.id),
+                    child: postTabView!,
                   ),
                 ),
-
-                if (postTabView != null)
-                  GrimityRefreshIndicator(
-                    onRefresh: () async {
-                      await Future.wait([
-                        ref.refresh(profilePostsDataProvider(user.id).future),
-                        ref.refresh(profileDataProvider(user.url).future),
-                      ]);
-                    },
-                    child: GrimityInfiniteScrollPagination(
-                      isEnabled:
-                          (() {
-                            final posts = ref.watch(profilePostsDataProvider(user.id)).valueOrNull;
-                            return user.id.isNotEmpty && posts != null && posts.length % 10 == 0;
-                          })(),
-                      onLoadMore: () => ref.read(profilePostsDataProvider(user.id).notifier).loadMore(user.id),
-                      child: postTabView!,
-                    ),
-                  ),
-              ],
-            ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
기존 프로필 페이지에서 사용하던 스크롤 구조가 변경되면서 계산식이 맞지 않게되어 수정 처리.

- NotificationListener, GlobalKey 제외
- Appbar.builder 사용하여 프로필 이름 투명도 계산 처리