### PR TITLE
feat: 차단한 유저와 채팅 불가 처리

### DIFF
--- a/lib/data/data_source/remote/chat_api.dart
+++ b/lib/data/data_source/remote/chat_api.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart' hide Headers;
 import 'package:grimity/data/model/chat/chat_search_response.dart';
 import 'package:grimity/data/model/common/id_response.dart';
-import 'package:grimity/data/model/user/user_base_with_blocked_response.dart';
+import 'package:grimity/data/model/user/opponent_user_response.dart';
 import 'package:grimity/domain/dto/chat_request_params.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
@@ -31,7 +31,7 @@ abstract class ChatAPI {
   Future<void> batchDeleteChat(@Body() BatchDeleteChatRequest request);
 
   @GET("/chats/{id}/user")
-  Future<UserBaseWithBlockedResponse> getUserByChat(@Path('id') String id);
+  Future<OpponentUserResponse> getUserByChat(@Path('id') String id);
 
   @PUT("/chats/{id}/join")
   Future<void> join(@Path('id') String id, @Body() SocketChatRequest request);

--- a/lib/data/model/user/opponent_user_response.dart
+++ b/lib/data/model/user/opponent_user_response.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:grimity/domain/entity/user.dart';
+
+part 'opponent_user_response.freezed.dart';
+
+part 'opponent_user_response.g.dart';
+
+@Freezed(copyWith: false)
+abstract class OpponentUserResponse with _$OpponentUserResponse {
+  const OpponentUserResponse._();
+
+  const factory OpponentUserResponse({
+    required String id,
+    required String name,
+    String? image,
+    required String url,
+    required bool isBlocked,
+    required bool isBlocking,
+  }) = _OpponentUserResponse;
+
+  factory OpponentUserResponse.fromJson(Map<String, dynamic> json) => _$OpponentUserResponseFromJson(json);
+}
+
+extension OpponentUserResponseX on OpponentUserResponse {
+  User toEntity() {
+    return User(
+      id: id,
+      name: name,
+      image: image,
+      url: url,
+      isBlocked: isBlocked,
+      isBlocking: isBlocking,
+    );
+  }
+}

--- a/lib/presentation/chat_message/provider/chat_message_provider.dart
+++ b/lib/presentation/chat_message/provider/chat_message_provider.dart
@@ -12,7 +12,7 @@ import 'package:grimity/data/model/chat_message/chat_message_item_response.dart'
 import 'package:grimity/data/model/chat_message/chat_message_reply_response.dart';
 import 'package:grimity/data/model/chat_message/chat_message_response.dart';
 import 'package:grimity/data/model/chat_message/chat_message_socket_response.dart';
-import 'package:grimity/data/model/user/user_base_with_blocked_response.dart';
+import 'package:grimity/data/model/user/opponent_user_response.dart';
 import 'package:grimity/domain/dto/chat_message_request_params.dart';
 import 'package:grimity/domain/dto/chat_request_params.dart';
 import 'package:grimity/domain/entity/image_upload_url.dart';
@@ -24,6 +24,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:socket_io_client/socket_io_client.dart' as io;
 
 part 'chat_message_provider.freezed.dart';
+
 part 'chat_message_provider.g.dart';
 
 @freezed
@@ -54,7 +55,7 @@ abstract class ChatMessage with _$ChatMessage {
 @freezed
 abstract class ChatMessageState with _$ChatMessageState {
   const factory ChatMessageState({
-    required UserBaseWithBlockedResponse opponentUser,
+    required OpponentUserResponse opponentUser,
     required String inputMessage,
     required List<ImageSourceItem> inputImages,
     required ChatMessageReplyResponse? inputReply,
@@ -65,7 +66,8 @@ abstract class ChatMessageState with _$ChatMessageState {
 
 extension ChatMessageStateExtension on ChatMessageState {
   /// 현재 메세지를 대상에게 보낼 수 있는지에 대한 여부.
-  bool get canSubmit => (inputImages.isNotEmpty || inputMessage.trim().isNotEmpty) && !opponentUser.isBlocked;
+  bool get canSubmit =>
+      (inputImages.isNotEmpty || inputMessage.trim().isNotEmpty) && !opponentUser.isBlocked && !opponentUser.isBlocking;
 }
 
 @riverpod
@@ -102,7 +104,7 @@ class ChatMessageProvider extends _$ChatMessageProvider {
 
     final historyResponse = responses[1] as ChatMessageResponse;
     final state = ChatMessageState(
-      opponentUser: responses[0] as UserBaseWithBlockedResponse,
+      opponentUser: responses[0] as OpponentUserResponse,
       inputMessage: "",
       inputImages: [],
       inputReply: null,
@@ -113,6 +115,8 @@ class ChatMessageProvider extends _$ChatMessageProvider {
     // 상대방이 차단한 경우, 별도의 안내 토스트 표시.
     if (state.opponentUser.isBlocked) {
       ToastService.showError("차단된 계정입니다.");
+    } else if (state.opponentUser.isBlocking) {
+      ToastService.showError("차단한 계정입니다.");
     }
 
     return state;
@@ -182,7 +186,8 @@ class ChatMessageProvider extends _$ChatMessageProvider {
 
   /// 사용자가 활성화된 '전송' 버튼을 눌렀을 때 호출됩니다.
   void submit() async {
-    assert(!_state.opponentUser.isBlocked, "차단한 유저에게는 메세지를 보낼 수 없습니다.");
+    assert(!_state.opponentUser.isBlocked, "차단된 유저에게는 메세지를 보낼 수 없습니다.");
+    assert(!_state.opponentUser.isBlocking, "차단한 유저에게는 메세지를 보낼 수 없습니다.");
     final uploadImages = <ImageUploadUrl>[];
 
     // 사용자가 대상에게 보낼 메세지에 이미지를 포함시킨 경우.

--- a/lib/presentation/chat_message/view/chat_message_app_bar.dart
+++ b/lib/presentation/chat_message/view/chat_message_app_bar.dart
@@ -5,7 +5,7 @@ import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/enum/report.enum.dart';
-import 'package:grimity/data/model/user/user_base_with_blocked_response.dart';
+import 'package:grimity/data/model/user/opponent_user_response.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/chat_message/components/show_delete_chat_dialog.dart';
 import 'package:grimity/presentation/chat_message/provider/chat_message_provider.dart';
@@ -40,7 +40,7 @@ class _BodyArea extends StatelessWidget {
   const _BodyArea({required this.chatId, required this.model});
 
   final String chatId;
-  final UserBaseWithBlockedResponse model;
+  final OpponentUserResponse model;
 
   void openBottomSheet(BuildContext context) {
     GrimityModalBottomSheet.show(

--- a/lib/presentation/chat_message/view/chat_message_field.dart
+++ b/lib/presentation/chat_message/view/chat_message_field.dart
@@ -89,7 +89,10 @@ class _TextFieldState extends ConsumerState<_TextField> {
     final providerFamily = chatMessageProviderProvider(chatId: widget.chatId);
     final provider = ref.read(providerFamily.notifier);
     final state = ref.watch(providerFamily);
-    final isEnabled = !(state.valueOrNull?.opponentUser.isBlocked ?? false);
+    final opponentUser = state.valueOrNull?.opponentUser;
+    final isBlocked = opponentUser?.isBlocked ?? false;
+    final isBlocking = opponentUser?.isBlocking ?? false;
+    final isEnabled = !(isBlocked || isBlocking);
 
     return IgnorePointer(
       ignoring: !isEnabled,


### PR DESCRIPTION
차단 기능 관련하여 DM에서 상대방을 차단한 경우에도 DM이 불가하게 처리

- 일반 DM
<img width="200" alt="simulator_screenshot_CB9A0BFB-98EF-484D-A962-047681D7BB71" src="https://github.com/user-attachments/assets/91987830-cc40-4aaa-af23-ebd74e3fe3b6" />

- 차단한 사용자 DM
<img width="200" alt="simulator_screenshot_987E13F0-70A3-4DD5-AE66-2A1ECB15B373" src="https://github.com/user-attachments/assets/58619744-42f6-4b24-8b2d-647b5158a2bd" />

- 차단당한 사용자 DM
<img width="200" alt="simulator_screenshot_232DCBC0-59CE-47B2-9B0F-ED8C3ECF9C56" src="https://github.com/user-attachments/assets/dd60509f-c09c-4c6c-a758-2e76df98db22" />
