### PR TITLE
refactor :: 메인 앱바, 바텀 넷바, FAB에 디자인 시스템을 연결 했습니다

### DIFF
--- a/lib/presentation/home/widget/home_app_bar.dart
+++ b/lib/presentation/home/widget/home_app_bar.dart
@@ -9,12 +9,9 @@ class HomeAppBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // 사용자 아바타 이미지 URL 가져오기
     final avatarImage = ref.watch(
       userAuthProvider.select((user) => user?.image),
     );
-
-    // 알림 여부 가져오기
     final hasNotification = ref.watch(
       userAuthProvider.select((user) => user?.hasNotification ?? false),
     );

--- a/lib/presentation/main/main_app_shell.dart
+++ b/lib/presentation/main/main_app_shell.dart
@@ -1,39 +1,51 @@
 import 'package:flutter/material.dart';
 import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
+import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/presentation/common/widget/grimity_pop_scope.dart';
 import 'package:grimity/presentation/drawer/main_app_drawer.dart';
-import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 import 'package:grimity/presentation/main/widget/main_bottom_navigation_bar.dart';
 import 'package:grimity/presentation/main/widget/main_floating_action_button.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class MainAppShell extends StatefulWidget {
+// GdsBottomNavigation.main() 아이템 순서와 동일
+const _tabRouteNames = [
+  HomeRoute.name,
+  RankingRoute.name,
+  FollowRoute.name,
+  BoardRoute.name,
+  ChatRoute.name,
+];
+
+class MainAppShell extends ConsumerStatefulWidget {
   const MainAppShell({super.key, required this.navigationShell});
 
   final StatefulNavigationShell navigationShell;
 
   @override
-  State<MainAppShell> createState() => _MainAppShellState();
+  ConsumerState<MainAppShell> createState() => _MainAppShellState();
 }
 
-class _MainAppShellState extends State<MainAppShell> {
+class _MainAppShellState extends ConsumerState<MainAppShell> {
+  static const _homeIndex = 0;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.gdsColors;
-    final canPop = widget.navigationShell.currentIndex == MainNavigationItem.home.index;
-    final showFab =
-        GoRouter.of(context).state.name == MainNavigationItem.values[widget.navigationShell.currentIndex].name;
+    final currentIndex = widget.navigationShell.currentIndex;
+    final canPop = currentIndex == _homeIndex;
+    final showFab = GoRouter.of(context).state.name == _tabRouteNames[currentIndex];
 
     return GrimityPopScope(
       canPop: canPop,
-      callback: () => widget.navigationShell.goBranch(MainNavigationItem.home.index),
+      callback: () => widget.navigationShell.goBranch(_homeIndex),
       child: Scaffold(
         backgroundColor: colors.bg.primary,
         endDrawer: MainAppDrawer(),
         body: widget.navigationShell,
         bottomNavigationBar: MainBottomNavigationBar(navigationShell: widget.navigationShell),
         floatingActionButton:
-            showFab ? MainFloatingActionButton(currentIndex: widget.navigationShell.currentIndex) : null,
+            showFab ? MainFloatingActionButton(currentIndex: currentIndex) : null,
       ),
     );
   }

--- a/lib/presentation/main/main_app_shell.dart
+++ b/lib/presentation/main/main_app_shell.dart
@@ -1,44 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
-import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/presentation/common/widget/grimity_pop_scope.dart';
 import 'package:grimity/presentation/drawer/main_app_drawer.dart';
+import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 import 'package:grimity/presentation/main/widget/main_bottom_navigation_bar.dart';
 import 'package:grimity/presentation/main/widget/main_floating_action_button.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-// GdsBottomNavigation.main() 아이템 순서와 동일
-const _tabRouteNames = [
-  HomeRoute.name,
-  RankingRoute.name,
-  FollowRoute.name,
-  BoardRoute.name,
-  ChatRoute.name,
-];
-
-class MainAppShell extends ConsumerStatefulWidget {
+class MainAppShell extends StatefulWidget {
   const MainAppShell({super.key, required this.navigationShell});
 
   final StatefulNavigationShell navigationShell;
 
   @override
-  ConsumerState<MainAppShell> createState() => _MainAppShellState();
+  State<MainAppShell> createState() => _MainAppShellState();
 }
 
-class _MainAppShellState extends ConsumerState<MainAppShell> {
-  static const _homeIndex = 0;
-
+class _MainAppShellState extends State<MainAppShell> {
   @override
   Widget build(BuildContext context) {
     final colors = context.gdsColors;
     final currentIndex = widget.navigationShell.currentIndex;
-    final canPop = currentIndex == _homeIndex;
-    final showFab = GoRouter.of(context).state.name == _tabRouteNames[currentIndex];
+    final currentItem = MainNavigationItem.values[currentIndex];
+    final canPop = currentIndex == MainNavigationItem.home.index;
+    final showFab = GoRouter.of(context).state.name == currentItem.routeName;
 
     return GrimityPopScope(
       canPop: canPop,
-      callback: () => widget.navigationShell.goBranch(_homeIndex),
+      callback: () => widget.navigationShell.goBranch(MainNavigationItem.home.index),
       child: Scaffold(
         backgroundColor: colors.bg.primary,
         endDrawer: MainAppDrawer(),

--- a/lib/presentation/main/main_app_shell.dart
+++ b/lib/presentation/main/main_app_shell.dart
@@ -44,8 +44,7 @@ class _MainAppShellState extends ConsumerState<MainAppShell> {
         endDrawer: MainAppDrawer(),
         body: widget.navigationShell,
         bottomNavigationBar: MainBottomNavigationBar(navigationShell: widget.navigationShell),
-        floatingActionButton:
-            showFab ? MainFloatingActionButton(currentIndex: currentIndex) : null,
+        floatingActionButton: showFab ? MainFloatingActionButton(currentIndex: currentIndex) : null,
       ),
     );
   }

--- a/lib/presentation/main/provider/main_bottom_navigation_item.dart
+++ b/lib/presentation/main/provider/main_bottom_navigation_item.dart
@@ -81,5 +81,4 @@ enum MainNavigationItem {
 
     return false;
   }
-
 }

--- a/lib/presentation/main/provider/main_bottom_navigation_item.dart
+++ b/lib/presentation/main/provider/main_bottom_navigation_item.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/config/app_router.dart';
-import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
 
 enum MainNavigationItem {
@@ -14,18 +13,33 @@ enum MainNavigationItem {
 
   const MainNavigationItem();
 
-  SvgGenImage get icon {
+  GdsIcon get gdsIcon {
     switch (this) {
       case MainNavigationItem.home:
-        return Assets.icons.icon.home;
+        return GdsIcon.home;
       case MainNavigationItem.ranking:
-        return Assets.icons.icon.paint;
+        return GdsIcon.paint;
       case MainNavigationItem.following:
-        return Assets.icons.icon.following;
+        return GdsIcon.following;
       case MainNavigationItem.board:
-        return Assets.icons.icon.board;
+        return GdsIcon.board;
       case MainNavigationItem.chatMessage:
-        return Assets.icons.icon.message;
+        return GdsIcon.message;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case MainNavigationItem.home:
+        return '홈';
+      case MainNavigationItem.ranking:
+        return '랭킹';
+      case MainNavigationItem.following:
+        return '팔로잉';
+      case MainNavigationItem.board:
+        return '자유게시판';
+      case MainNavigationItem.chatMessage:
+        return 'DM';
     }
   }
 
@@ -68,36 +82,4 @@ enum MainNavigationItem {
     return false;
   }
 
-  Widget build(
-    BuildContext context,
-    WidgetRef ref,
-    Widget child,
-  ) {
-    return shouldVisibleBadge(ref) ? badgeWith(child: child) : child;
-  }
-
-  /// 배지를 표시하도록 위젯 트리를 재구성합니다.
-  Widget badgeWith({required Widget child}) {
-    return Stack(
-      children: [
-        child,
-        Positioned.fill(
-          child: Align(
-            alignment: Alignment.topRight,
-            child: Transform.translate(
-              offset: Offset(0, 5),
-              child: Container(
-                width: 6,
-                height: 6,
-                decoration: BoxDecoration(
-                  color: AppColor.accentRed,
-                  shape: BoxShape.circle,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }

--- a/lib/presentation/main/provider/main_bottom_navigation_item.dart
+++ b/lib/presentation/main/provider/main_bottom_navigation_item.dart
@@ -50,7 +50,7 @@ enum MainNavigationItem {
       case MainNavigationItem.ranking:
         return RankingRoute.name;
       case MainNavigationItem.following:
-        return FollowRoute.name;
+        return FollowingRoute.name;
       case MainNavigationItem.board:
         return BoardRoute.name;
       case MainNavigationItem.chatMessage:

--- a/lib/presentation/main/widget/main_bottom_navigation_bar.dart
+++ b/lib/presentation/main/widget/main_bottom_navigation_bar.dart
@@ -1,74 +1,48 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
+import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/presentation/common/widget/grimity_animation_button.dart';
-import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
+import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class MainBottomNavigationBar extends StatelessWidget {
-  final StatefulNavigationShell navigationShell;
-
+class MainBottomNavigationBar extends ConsumerWidget {
   const MainBottomNavigationBar({super.key, required this.navigationShell});
 
+  final StatefulNavigationShell navigationShell;
+
+  static const _chatMessageIndex = 4;
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.gdsColors;
+    final currentIndex = navigationShell.currentIndex;
+    final hasUnreadChat = ref.watch(userAuthProvider)?.hasUnreadChatMessage ?? false;
+    final dotIndex = hasUnreadChat ? _chatMessageIndex : null;
+
     return SafeArea(
       top: false,
       child: Container(
         height: 58,
-        padding: EdgeInsets.symmetric(horizontal: 18),
+        padding: const EdgeInsets.symmetric(horizontal: 18),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: .9),
-          border: Border(top: BorderSide(color: AppColor.gray300.withValues(alpha: .9))),
-          boxShadow: [BoxShadow(offset: Offset(0, -2), color: Colors.black.withValues(alpha: .04), blurRadius: 6)],
-        ),
-        child: Row(
-          spacing: 16,
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children:
-              MainNavigationItem.values
-                  .map((e) => _MainBottomNavItem(item: e, navigationShell: navigationShell))
-                  .toList(),
-        ),
-      ),
-    );
-  }
-}
-
-class _MainBottomNavItem extends ConsumerWidget {
-  const _MainBottomNavItem({required this.item, required this.navigationShell});
-
-  final MainNavigationItem item;
-  final StatefulNavigationShell navigationShell;
-
-  bool get isActive => navigationShell.currentIndex == item.index;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Expanded(
-      child: GrimityAnimationButton(
-        onTap: () => goBranch(item.index, isActive),
-        child: Center(
-          child: Padding(
-            padding: EdgeInsets.only(bottom: 12),
-            child: item.build(
-              context,
-              ref,
-              SvgPicture.asset(
-                item.icon.path,
-                width: 22,
-                height: 22,
-                colorFilter: ColorFilter.mode(isActive ? AppColor.gray700 : AppColor.gray500, BlendMode.srcIn),
-              ),
+          color: colors.bg.primary.withValues(alpha: .9),
+          border: Border(top: BorderSide(color: colors.border.graySubtle.withValues(alpha: .9))),
+          boxShadow: [
+            BoxShadow(
+              offset: const Offset(0, -2),
+              color: colors.bg.black.withValues(alpha: .04),
+              blurRadius: 6,
             ),
+          ],
+        ),
+        child: GdsBottomNavigation.main(
+          index: currentIndex,
+          dotIndex: dotIndex,
+          onPressed: (index) => navigationShell.goBranch(
+            index,
+            initialLocation: index == currentIndex,
           ),
         ),
       ),
     );
-  }
-
-  void goBranch(int index, bool initialLocation) {
-    navigationShell.goBranch(index, initialLocation: initialLocation);
   }
 }

--- a/lib/presentation/main/widget/main_bottom_navigation_bar.dart
+++ b/lib/presentation/main/widget/main_bottom_navigation_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
-import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
+import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class MainBottomNavigationBar extends ConsumerWidget {
@@ -9,14 +9,12 @@ class MainBottomNavigationBar extends ConsumerWidget {
 
   final StatefulNavigationShell navigationShell;
 
-  static const _chatMessageIndex = 4;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.gdsColors;
     final currentIndex = navigationShell.currentIndex;
-    final hasUnreadChat = ref.watch(userAuthProvider)?.hasUnreadChatMessage ?? false;
-    final dotIndex = hasUnreadChat ? _chatMessageIndex : null;
+    final chatItem = MainNavigationItem.chatMessage;
+    final dotIndex = chatItem.shouldVisibleBadge(ref) ? chatItem.index : null;
 
     return SafeArea(
       top: false,

--- a/lib/presentation/main/widget/main_bottom_navigation_bar.dart
+++ b/lib/presentation/main/widget/main_bottom_navigation_bar.dart
@@ -37,10 +37,11 @@ class MainBottomNavigationBar extends ConsumerWidget {
         child: GdsBottomNavigation.main(
           index: currentIndex,
           dotIndex: dotIndex,
-          onPressed: (index) => navigationShell.goBranch(
-            index,
-            initialLocation: index == currentIndex,
-          ),
+          onPressed:
+              (index) => navigationShell.goBranch(
+                index,
+                initialLocation: index == currentIndex,
+              ),
         ),
       ),
     );

--- a/lib/presentation/main/widget/main_floating_action_button.dart
+++ b/lib/presentation/main/widget/main_floating_action_button.dart
@@ -1,32 +1,51 @@
 import 'package:flutter/material.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
+import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
-import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
-import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 
 class MainFloatingActionButton extends StatelessWidget {
   const MainFloatingActionButton({super.key, required this.currentIndex});
 
   final int currentIndex;
 
+  // GdsBottomNavigation.main() 아이템 순서 기준
+  static const _boardIndex = 3;
+  static const _chatMessageIndex = 4;
+
   @override
   Widget build(BuildContext context) {
-    final assetImage =
-        currentIndex == MainNavigationItem.board.index ? Assets.icons.icon.plusPost : Assets.icons.icon.plus;
+    final colors = context.gdsColors;
+    final assetImage = currentIndex == _boardIndex ? Assets.icons.icon.plusPost : Assets.icons.icon.plus;
 
-    return GrimityGesture(
-      onTap: () => MainNavigationItem.values[currentIndex].onFabTap(context),
+    return GdsGesture(
+      onTap: () => _onFabTap(context),
       child: Container(
-        width: 48,
-        height: 48,
-        decoration: BoxDecoration(shape: BoxShape.circle, color: AppColor.primary4),
+        width: 54,
+        height: 54,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: colors.surface.primaryNormal,
+          boxShadow: GdsShadows.level2,
+        ),
         child: assetImage.svg(
           width: 24,
           height: 24,
           fit: BoxFit.scaleDown,
-          colorFilter: ColorFilter.mode(AppColor.gray00, BlendMode.srcIn),
+          colorFilter: ColorFilter.mode(colors.icon.white, BlendMode.srcIn),
         ),
       ),
     );
+  }
+
+  void _onFabTap(BuildContext context) {
+    switch (currentIndex) {
+      case _boardIndex:
+        PostUploadRoute().push(context);
+      case _chatMessageIndex:
+        NewChatRoute().push(context);
+      default:
+        FeedUploadRoute().push(context);
+    }
   }
 }

--- a/lib/presentation/main/widget/main_floating_action_button.dart
+++ b/lib/presentation/main/widget/main_floating_action_button.dart
@@ -1,24 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:gds/gds.dart';
-import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/main/provider/main_bottom_navigation_item.dart';
 
 class MainFloatingActionButton extends StatelessWidget {
   const MainFloatingActionButton({super.key, required this.currentIndex});
 
   final int currentIndex;
 
-  // GdsBottomNavigation.main() 아이템 순서 기준
-  static const _boardIndex = 3;
-  static const _chatMessageIndex = 4;
-
   @override
   Widget build(BuildContext context) {
     final colors = context.gdsColors;
-    final assetImage = currentIndex == _boardIndex ? Assets.icons.icon.plusPost : Assets.icons.icon.plus;
+    final currentItem = MainNavigationItem.values[currentIndex];
+    final assetImage = currentItem == MainNavigationItem.board ? Assets.icons.icon.plusPost : Assets.icons.icon.plus;
 
     return GdsGesture(
-      onTap: () => _onFabTap(context),
+      onTap: () => currentItem.onFabTap(context),
       child: Container(
         width: 54,
         height: 54,
@@ -36,16 +33,5 @@ class MainFloatingActionButton extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  void _onFabTap(BuildContext context) {
-    switch (currentIndex) {
-      case _boardIndex:
-        PostUploadRoute().push(context);
-      case _chatMessageIndex:
-        NewChatRoute().push(context);
-      default:
-        FeedUploadRoute().push(context);
-    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
+      resolved-ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
-      resolved-ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
+      ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
+      resolved-ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
-      resolved-ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
+      ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
+      resolved-ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
-      resolved-ref: ac75fe0f17944d94b88bd962d5fa146fe6313e97
+      ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
+      resolved-ref: "84f0e3f0f93ed8cc5f6da0768bfd3ef543f41c4a"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1589,10 +1589,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1613,10 +1613,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2306,10 +2306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- `HomeAppBar`: `GdsTopNavigation.main` 적용 및 `userAuthProvider`의 `hasNotification` 연결
- `MainBottomNavigationBar`: `GdsBottomNavigation.main` 적용, `hasUnreadChatMessage` 기반 dot 배지 연결, `onPressed`로 `goBranch` 호출
- `MainAppShell`: `ConsumerStatefulWidget`으로 전환, 탭 인덱스↔라우트 매핑을 상수 리스트로 정리
- `MainFloatingActionButton`: `GdsGesture` / `GdsShadows.level2` / semantic color 적용, 라우팅 분기를 위젯 내부로 이동
- `MainNavigationItem`: `GdsIcon`/`label` 매핑으로 정리하고 기존 SVG/배지 빌드 로직 제거

## Test plan
- [x] 홈 화면 진입 시 상단 앱바 노출 및 알림 여부에 따라 bell 아이콘 fill/outline 정상 전환
- [x] 바텀 넷바 탭 시 scale bounce 애니메이션 및 페이지 전환 정상 동작
- [x] 읽지 않은 채팅이 있을 때 DM 탭에 dot 배지 표시
- [x] FAB 탭 시 현재 탭(board/dm/그외)에 맞는 업로드 라우트로 이동