### PR TITLE
refactor :: Notification 스크린에 디자인 시스템 연결

### DIFF
--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -15,6 +15,7 @@ class AlbumEditAppBar extends ConsumerWidget {
     return GdsTopNavigation.editor(
       title: '앨범 편집',
       label: context.isMobile ? '저장' : '저장하기',
+      onBack: () => context.pop(),
       onTitle: () {},
       onSave: () async {
         final saved = await notifier.saveChanges();

--- a/lib/presentation/common/widget/grimity_state_view.dart
+++ b/lib/presentation/common/widget/grimity_state_view.dart
@@ -67,6 +67,7 @@ class GrimityStateView extends StatelessWidget {
 
   /// resultNull icon
   factory GrimityStateView.resultNull({
+    SvgGenImage? icon,
     String? title,
     String? subTitle,
     String? buttonText,
@@ -79,7 +80,7 @@ class GrimityStateView extends StatelessWidget {
     ButtonColorType buttonColor = ButtonColorType.mono,
     ButtonStyleType buttonStyleType = ButtonStyleType.solid,
   }) => GrimityStateView._(
-    icon: Assets.icons.illust.resultNull,
+    icon: icon ?? Assets.icons.illust.resultNull,
     title: title,
     subTitle: subTitle,
     buttonText: buttonText,

--- a/lib/presentation/common/widget/grimity_state_view.dart
+++ b/lib/presentation/common/widget/grimity_state_view.dart
@@ -7,6 +7,7 @@ import 'package:grimity/presentation/common/widget/button/grimity_button.dart';
 class GrimityStateView extends StatelessWidget {
   const GrimityStateView._({
     required this.icon,
+    this.customIcon,
     this.title,
     this.subTitle,
     this.buttonText,
@@ -21,6 +22,7 @@ class GrimityStateView extends StatelessWidget {
   });
 
   final SvgGenImage icon;
+  final Widget? customIcon;
   final String? title;
   final String? subTitle;
   final String? buttonText;
@@ -68,6 +70,7 @@ class GrimityStateView extends StatelessWidget {
   /// resultNull icon
   factory GrimityStateView.resultNull({
     SvgGenImage? icon,
+    Widget? customIcon,
     String? title,
     String? subTitle,
     String? buttonText,
@@ -81,6 +84,7 @@ class GrimityStateView extends StatelessWidget {
     ButtonStyleType buttonStyleType = ButtonStyleType.solid,
   }) => GrimityStateView._(
     icon: icon ?? Assets.icons.illust.resultNull,
+    customIcon: customIcon,
     title: title,
     subTitle: subTitle,
     buttonText: buttonText,
@@ -206,7 +210,7 @@ class GrimityStateView extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [
-            icon.svg(width: 60, height: 60),
+            customIcon ?? icon.svg(width: 60, height: 60),
             Column(
               spacing: 8,
               children: [

--- a/lib/presentation/notification/notification_page.dart
+++ b/lib/presentation/notification/notification_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/notification.dart';
-import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/notification/notification_view.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
@@ -53,7 +52,7 @@ class NotificationPage extends ConsumerWidget {
                   (notifications) =>
                       notifications.isEmpty
                           ? GrimityStateView.resultNull(
-                            icon: Assets.icons.illust.alram,
+                            customIcon: GdsIcon.alarmDark.build(width: 60, height: 60),
                             title: '새로운 알림이 없어요',
                             subTitle: '내 글의 댓글와 좋아요, 다른 작가의 활동 등\n새로운 소식을 알려드려요',
                           )

--- a/lib/presentation/notification/notification_page.dart
+++ b/lib/presentation/notification/notification_page.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/notification.dart';
+import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:grimity/presentation/notification/notification_view.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/presentation/notification/view/notification_body_view.dart';
+import 'package:grimity/presentation/notification/widget/notification_action_button.dart';
 import 'package:grimity/presentation/notification/widget/notification_app_bar.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -14,20 +18,51 @@ class NotificationPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notificationAsync = ref.watch(notificationDataProvider);
+    final notifier = ref.read(notificationDataProvider.notifier);
+    final colors = context.gdsColors;
+    final hasNotifications = notificationAsync.valueOrNull?.isNotEmpty ?? false;
 
     return NotificationView(
       notificationAppBar: NotificationAppBar(),
-      notificationBody: notificationAsync.when(
-        data:
-            (notifications) =>
-                notifications.isEmpty
-                    ? GrimityStateView.resultNull(
-                      title: '새로운 알림이 없어요',
-                      subTitle: '내 글의 댓글와 좋아요, 다른 작가의 활동 등\n새로운 소식을 알려드려요',
-                    )
-                    : NotificationBodyView(notifications: notifications),
-        loading: () => Skeletonizer(child: NotificationBodyView(notifications: Notification.emptyList)),
-        error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(notificationDataProvider)),
+      notificationBody: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(GdsSpacing.spacing16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                NotificationActionButton(
+                  title: '전체 읽음',
+                  onTap: hasNotifications ? () => notifier.markAllNotificationAsRead() : null,
+                  icon: GdsIcon.eyeOn,
+                ),
+                const Gap(GdsSpacing.spacing8),
+                Container(width: 1, height: 12, color: colors.border.graySubtler),
+                const Gap(GdsSpacing.spacing8),
+                NotificationActionButton(
+                  title: '전체 삭제',
+                  onTap: hasNotifications ? () => notifier.deleteAllNotification() : null,
+                  icon: GdsIcon.trash,
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: notificationAsync.when(
+              data:
+                  (notifications) =>
+                      notifications.isEmpty
+                          ? GrimityStateView.resultNull(
+                            icon: Assets.icons.illust.alram,
+                            title: '새로운 알림이 없어요',
+                            subTitle: '내 글의 댓글와 좋아요, 다른 작가의 활동 등\n새로운 소식을 알려드려요',
+                          )
+                          : NotificationBodyView(notifications: notifications),
+              loading: () => Skeletonizer(child: NotificationBodyView(notifications: Notification.emptyList)),
+              error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(notificationDataProvider)),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/notification/notification_view.dart
+++ b/lib/presentation/notification/notification_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gds/gds.dart';
 
 class NotificationView extends ConsumerWidget {
   const NotificationView({super.key, required this.notificationAppBar, required this.notificationBody});
@@ -9,6 +10,10 @@ class NotificationView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(appBar: notificationAppBar, body: notificationBody);
+    return Scaffold(
+      backgroundColor: context.gdsColors.bg.primary,
+      appBar: notificationAppBar,
+      body: notificationBody,
+    );
   }
 }

--- a/lib/presentation/notification/notification_view.dart
+++ b/lib/presentation/notification/notification_view.dart
@@ -5,13 +5,12 @@ import 'package:gds/gds.dart';
 class NotificationView extends ConsumerWidget {
   const NotificationView({super.key, required this.notificationAppBar, required this.notificationBody});
 
-  final PreferredSizeWidget notificationAppBar;
+  final Widget notificationAppBar;
   final Widget notificationBody;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      backgroundColor: context.gdsColors.bg.primary,
+    return GdsScaffold(
       appBar: notificationAppBar,
       body: notificationBody,
     );

--- a/lib/presentation/notification/view/notification_body_view.dart
+++ b/lib/presentation/notification/view/notification_body_view.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/gen/assets.gen.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/domain/entity/notification.dart';
 import 'package:grimity/presentation/notification/widget/notification_action_button.dart';
@@ -16,27 +15,28 @@ class NotificationBodyView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(notificationDataProvider.notifier);
+    final colors = context.gdsColors;
 
     return CustomScrollView(
       slivers: [
         SliverToBoxAdapter(
           child: Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(GdsSpacing.spacing16),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 NotificationActionButton(
                   title: '전체 읽음',
                   onTap: () => notifier.markAllNotificationAsRead(),
-                  icon: Assets.icons.icon.eye,
+                  icon: GdsIcon.eyeOn,
                 ),
-                Gap(8),
-                VerticalDivider(color: AppColor.gray300, width: 1),
-                Gap(8),
+                const Gap(GdsSpacing.spacing8),
+                VerticalDivider(color: colors.border.graySubtler, width: 1),
+                const Gap(GdsSpacing.spacing8),
                 NotificationActionButton(
                   title: '전체 삭제',
                   onTap: () => notifier.deleteAllNotification(),
-                  icon: Assets.icons.icon.trash,
+                  icon: GdsIcon.trash,
                 ),
               ],
             ),
@@ -48,7 +48,7 @@ class NotificationBodyView extends ConsumerWidget {
 
             return NotificationWidget(notification: notification);
           },
-          separatorBuilder: (context, index) => Divider(height: 1, color: AppColor.gray300),
+          separatorBuilder: (context, index) => Divider(height: 1, color: colors.border.graySubtler),
           itemCount: notifications.length,
         ),
       ],

--- a/lib/presentation/notification/view/notification_body_view.dart
+++ b/lib/presentation/notification/view/notification_body_view.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:gap/gap.dart';
 import 'package:gds/gds.dart';
-import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/domain/entity/notification.dart';
-import 'package:grimity/presentation/notification/widget/notification_action_button.dart';
 import 'package:grimity/presentation/notification/widget/notification_widget.dart';
 
 class NotificationBodyView extends ConsumerWidget {
@@ -14,34 +11,10 @@ class NotificationBodyView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notifier = ref.read(notificationDataProvider.notifier);
     final colors = context.gdsColors;
 
     return CustomScrollView(
       slivers: [
-        SliverToBoxAdapter(
-          child: Padding(
-            padding: const EdgeInsets.all(GdsSpacing.spacing16),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                NotificationActionButton(
-                  title: '전체 읽음',
-                  onTap: () => notifier.markAllNotificationAsRead(),
-                  icon: GdsIcon.eyeOn,
-                ),
-                const Gap(GdsSpacing.spacing8),
-                VerticalDivider(color: colors.border.graySubtler, width: 1),
-                const Gap(GdsSpacing.spacing8),
-                NotificationActionButton(
-                  title: '전체 삭제',
-                  onTap: () => notifier.deleteAllNotification(),
-                  icon: GdsIcon.trash,
-                ),
-              ],
-            ),
-          ),
-        ),
         SliverList.separated(
           itemBuilder: (context, index) {
             final notification = notifications[index];

--- a/lib/presentation/notification/widget/notification_action_button.dart
+++ b/lib/presentation/notification/widget/notification_action_button.dart
@@ -6,21 +6,24 @@ class NotificationActionButton extends StatelessWidget {
   const NotificationActionButton({super.key, required this.title, required this.onTap, required this.icon});
 
   final String title;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final GdsIcon icon;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.gdsColors;
+    final enabled = onTap != null;
+    final textColor = enabled ? colors.text.grayBold : colors.text.graySubtler;
+    final iconColor = enabled ? colors.icon.graySubtle : colors.icon.graySubtler;
 
     return GdsGesture(
       onTap: onTap,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          icon.build(width: 16, height: 16, color: colors.icon.graySubtle),
+          icon.build(width: 16, height: 16, color: iconColor),
           const Gap(GdsSpacing.spacing6),
-          Text(title, style: GdsTypography.caption1.copyWith(color: colors.text.grayBold)),
+          Text(title, style: GdsTypography.caption1.copyWith(color: textColor)),
         ],
       ),
     );

--- a/lib/presentation/notification/widget/notification_action_button.dart
+++ b/lib/presentation/notification/widget/notification_action_button.dart
@@ -1,34 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/app/config/app_typeface.dart';
-import 'package:grimity/gen/assets.gen.dart';
-import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
+import 'package:gds/gds.dart';
 
 class NotificationActionButton extends StatelessWidget {
   const NotificationActionButton({super.key, required this.title, required this.onTap, required this.icon});
 
   final String title;
   final VoidCallback onTap;
-  final SvgGenImage icon;
+  final GdsIcon icon;
 
   @override
   Widget build(BuildContext context) {
-    return GrimityGesture(
+    final colors = context.gdsColors;
+
+    return GdsGesture(
       onTap: onTap,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          icon.svg(
-            width: 16,
-            height: 16,
-            colorFilter: ColorFilter.mode(
-              AppColor.gray500,
-              BlendMode.srcIn,
-            ),
-          ),
-          Gap(6),
-          Text(title, style: AppTypeface.caption2.copyWith(color: AppColor.gray700)),
+          icon.build(width: 16, height: 16, color: colors.icon.graySubtle),
+          const Gap(GdsSpacing.spacing6),
+          Text(title, style: GdsTypography.caption1.copyWith(color: colors.text.grayNormal)),
         ],
       ),
     );

--- a/lib/presentation/notification/widget/notification_action_button.dart
+++ b/lib/presentation/notification/widget/notification_action_button.dart
@@ -20,7 +20,7 @@ class NotificationActionButton extends StatelessWidget {
         children: [
           icon.build(width: 16, height: 16, color: colors.icon.graySubtle),
           const Gap(GdsSpacing.spacing6),
-          Text(title, style: GdsTypography.caption1.copyWith(color: colors.text.grayNormal)),
+          Text(title, style: GdsTypography.caption1.copyWith(color: colors.text.grayBold)),
         ],
       ),
     );

--- a/lib/presentation/notification/widget/notification_app_bar.dart
+++ b/lib/presentation/notification/widget/notification_app_bar.dart
@@ -3,10 +3,8 @@ import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_router.dart';
 
-class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget {
+class NotificationAppBar extends StatelessWidget {
   const NotificationAppBar({super.key});
-
-  static const double _height = GdsSpacing.spacing56;
 
   @override
   Widget build(BuildContext context) {
@@ -17,7 +15,4 @@ class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget 
       onIconTap: [() => SettingRoute().push(context)],
     );
   }
-
-  @override
-  Size get preferredSize => const Size.fromHeight(_height);
 }

--- a/lib/presentation/notification/widget/notification_app_bar.dart
+++ b/lib/presentation/notification/widget/notification_app_bar.dart
@@ -1,33 +1,26 @@
 import 'package:flutter/material.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
+import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_router.dart';
-import 'package:grimity/app/config/app_theme.dart';
-import 'package:grimity/app/config/app_typeface.dart';
-import 'package:grimity/gen/assets.gen.dart';
-import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 
 class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget {
   const NotificationAppBar({super.key});
 
+  static const double _height = GdsSpacing.spacing56;
+
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      toolbarHeight: AppTheme.kToolbarHeight.height,
-      title: Text('알림', style: AppTypeface.subTitle3),
-      titleSpacing: 0,
-      actions: [
-        GrimityGesture(
-          onTap: () => SettingRoute().push(context),
-          child: Assets.icons.icon.setting.svg(width: 24, height: 24),
-        ),
-      ],
-      bottom: const PreferredSize(
-        preferredSize: Size.fromHeight(1),
-        child: Divider(height: 1, color: AppColor.gray300),
+    return SafeArea(
+      bottom: false,
+      child: GdsTopNavigation.iconButton(
+        title: '알림',
+        onBack: () => context.pop(),
+        icons: const [GdsIcon.settings],
+        onIconTap: [() => SettingRoute().push(context)],
       ),
     );
   }
 
   @override
-  Size get preferredSize => AppTheme.kToolbarHeight;
+  Size get preferredSize => const Size.fromHeight(_height);
 }

--- a/lib/presentation/notification/widget/notification_app_bar.dart
+++ b/lib/presentation/notification/widget/notification_app_bar.dart
@@ -10,14 +10,11 @@ class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget 
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      bottom: false,
-      child: GdsTopNavigation.iconButton(
-        title: '알림',
-        onBack: () => context.pop(),
-        icons: const [GdsIcon.settings],
-        onIconTap: [() => SettingRoute().push(context)],
-      ),
+    return GdsTopNavigation.iconButton(
+      title: '알림',
+      onBack: () => context.pop(),
+      icons: const [GdsIcon.settings],
+      onIconTap: [() => SettingRoute().push(context)],
     );
   }
 

--- a/lib/presentation/notification/widget/notification_widget.dart
+++ b/lib/presentation/notification/widget/notification_widget.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/app/config/app_typeface.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/app/linking/url_handler.dart';
-import 'package:grimity/gen/assets.gen.dart';
-import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
 import 'package:grimity/presentation/common/widget/system/profile/grimity_user_profile.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/domain/entity/notification.dart';
@@ -19,6 +16,7 @@ class NotificationWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(notificationDataProvider.notifier);
+    final colors = context.gdsColors;
 
     return InkWell(
       onTap: () {
@@ -29,31 +27,27 @@ class NotificationWidget extends ConsumerWidget {
         UrlHandler.handleServerUrl(context, notification.link);
       },
       child: Container(
-        padding: EdgeInsets.all(16),
+        padding: const EdgeInsets.all(GdsSpacing.spacing16),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
               child: GrimityUserProfile.fromBuilder(
                 imageUrl: notification.image ?? '',
-                titleBuilder: () => _buildNotificationText(notification.message),
+                titleBuilder: () => _buildNotificationText(context, notification.message),
                 subTitleBuilder:
                     () => Text(
                       notification.createdAt.toRelativeTime(),
-                      style: AppTypeface.caption2.copyWith(
-                        color: AppColor.gray600.withValues(alpha: notification.isRead ? 0.5 : 1.0),
+                      style: GdsTypography.caption1.copyWith(
+                        color: colors.text.grayNormal.withValues(alpha: notification.isRead ? 0.5 : 1.0),
                       ),
                     ),
               ),
             ),
-            Gap(8),
-            GrimityGesture(
+            const Gap(GdsSpacing.spacing8),
+            GdsGesture(
               onTap: () => notifier.deleteNotification(notification.id),
-              child: Assets.icons.icon.close.svg(
-                width: 20,
-                height: 20,
-                colorFilter: ColorFilter.mode(AppColor.gray500, BlendMode.srcIn),
-              ),
+              child: GdsIcon.xMark.build(width: 20, height: 20, color: colors.icon.graySubtle),
             ),
           ],
         ),
@@ -65,11 +59,11 @@ class NotificationWidget extends ConsumerWidget {
   /// - 문장에 "님이"가 있을 경우: 마지막 "님이" 앞까지를 닉네임으로 인식하여 볼드 처리
   /// - 문장에 "…에 좋아요가" 패턴이 있을 경우: "에 좋아요가" 앞의 대상을 추출하여 볼드 처리
   /// - 두 패턴이 없으면: 전체 문자열을 일반 Text로 반환
-  Widget _buildNotificationText(String message) {
-    final styleBase = AppTypeface.label3.copyWith(
-      color: AppColor.gray800.withValues(alpha: notification.isRead ? 0.5 : 1.0),
+  Widget _buildNotificationText(BuildContext context, String message) {
+    final styleBase = GdsTypography.body2R.copyWith(
+      color: context.gdsColors.text.grayBold.withValues(alpha: notification.isRead ? 0.5 : 1.0),
     );
-    final styleBold = styleBase.copyWith(fontWeight: FontWeight.bold);
+    final styleBold = GdsTypography.body2SB.copyWith(color: styleBase.color);
 
     final pattern = RegExp(r'^(.+?)님이|^(.+?)에 좋아요가');
     final matches = pattern.allMatches(message).toList();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
-      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
-      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
-      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1589,18 +1589,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mesh_gradient:
     dependency: "direct main"
     description:
@@ -1613,10 +1613,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2306,10 +2306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
+      resolved-ref: "47b50bb6553a90c9fb588c56cc04f1f46630c2b5"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1589,18 +1589,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   mesh_gradient:
     dependency: "direct main"
     description:
@@ -1613,10 +1613,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -2306,10 +2306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.6"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
Resolves #160

## Summary
- NotificationAppBar: `GdsTopNavigation.iconButton` 적용, `onBack: () => context.pop()` 연결
- NotificationActionButton: `GdsIcon` / `GdsTypography` / `GdsGesture` / semantic color로 교체, icon 파라미터 타입을 `SvgGenImage → GdsIcon`으로 변경
- NotificationWidget: `GdsIcon.xMark` / `GdsTypography.body2R`·`body2SB`·`caption1` / `GdsGesture` / semantic color 적용
- NotificationBodyView: `colors.border.graySubtler` 디바이더, `GdsSpacing` 적용
- NotificationView: `colors.bg.primary` 배경 토큰 적용
- AlbumEditAppBar: gds-flutter breaking change(#19) 대응 — `GdsTopNavigation.editor`에 `onBack: () => context.pop()` 추가
- `pubspec.lock`: gds ref `e4a6b1d → 47b50bb` 갱신 (Grimity/gds-flutter#20 포함)

## 토큰 매핑
| 기존 | 신규 |
| --- | --- |
| `AppTypeface.subTitle3` | `GdsTypography.subtitle2` (GdsTopNavigation 내부 기본값) |
| `AppTypeface.caption2` | `GdsTypography.caption1` |
| `AppTypeface.label3` (메시지 본문) | `GdsTypography.body2R` / `body2SB` |
| `AppColor.gray300` (디바이더) | `colors.border.graySubtler` |
| `AppColor.gray500` (아이콘) | `colors.icon.graySubtle` |
| `AppColor.gray600` (타임스탬프) | `colors.text.grayNormal` |
| `AppColor.gray700`·`gray800` (텍스트) | `colors.text.grayBold` |
| `Assets.icons.icon.close` | `GdsIcon.xMark` |
| `Assets.icons.icon.eye` | `GdsIcon.eyeOn` |
| `Assets.icons.icon.trash` | `GdsIcon.trash` |
| `Assets.icons.icon.setting` | `GdsIcon.settings` |
| `GrimityGesture` | `GdsGesture` |

## Test plan
- [x] `fvm flutter analyze` 전체 통과
- [ ] 알림 화면 진입/뒤로가기 동작 확인
- [ ] 전체 읽음 / 전체 삭제 버튼 동작 확인
- [ ] 알림 아이템 탭/삭제 동작 확인
- [ ] 읽음/안읽음 상태 알파 처리 확인
- [ ] 앨범 편집 화면 뒤로가기 동작 확인 (gds-flutter onBack 적용 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)