### PR TITLE
feat: Album Organize 페이지에 디자인 시스템 적용

### DIFF
--- a/lib/presentation/album_edit/provider/album_edit_provider.dart
+++ b/lib/presentation/album_edit/provider/album_edit_provider.dart
@@ -137,21 +137,22 @@ class AlbumEdit extends _$AlbumEdit {
   }
 
   // 앨범 수정
-  void updateAlbum(Album album) {
+  bool updateAlbum(Album album) {
     final name = album.name.trim();
 
     if (!ValidatorUtil.isValidAlbumName(name)) {
       ToastService.showFailure('앨범명 최대 15자까지만 가능해요');
-      return;
+      return false;
     }
 
     if (_hasDuplicateName(name, excludingId: album.id)) {
       ToastService.showFailure('중복된 이름은 사용하실 수 없어요');
-      return;
+      return false;
     }
 
     final updated = state.albums.map((item) => item.id == album.id ? album.copyWith(name: name) : item).toList();
     state = state.copyWith(albums: updated, editAlbum: null);
+    return true;
   }
 
   Future<bool> saveChanges() async {

--- a/lib/presentation/album_edit/view/album_reorderable_list_view.dart
+++ b/lib/presentation/album_edit/view/album_reorderable_list_view.dart
@@ -4,6 +4,7 @@ import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/album.dart';
 import 'package:grimity/presentation/album_edit/provider/album_edit_provider.dart';
 import 'package:grimity/presentation/album_edit/widget/album_delete_dialog.dart';
+import 'package:grimity/presentation/album_edit/widget/album_edit.dart';
 
 class AlbumReorderableListView extends ConsumerWidget {
   const AlbumReorderableListView({super.key});
@@ -46,70 +47,7 @@ class AlbumReorderableListView extends ConsumerWidget {
             text: album.name,
             state: isSorting ? GdsGroupSettingState.enabled : GdsGroupSettingState.editDelete,
             onTap: isSorting ? null : () => showAlbumDeleteDialog(context, ref, album),
-            onEditTap: () {
-              final editController = TextEditingController(text: album.name);
-              final editFocusNode = FocusNode();
-
-              void closeNameEditor() {
-                editFocusNode.unfocus();
-                Navigator.pop(context);
-              }
-
-              void disposeNameEditor() {
-                editFocusNode.unfocus();
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  editController.dispose();
-                  editFocusNode.dispose();
-                });
-              }
-
-              onPrimaryTap() {
-                final editedName = editController.text.trim();
-                if (editedName == album.name.trim()) {
-                  closeNameEditor();
-                  return;
-                }
-
-                final editedAlbum = album.copyWith(name: editedName);
-                ref.read(albumEditProvider.notifier).updateAlbum(editedAlbum);
-                closeNameEditor();
-              }
-
-              if (context.isMobile) {
-                final bottomSheet = GdsBottomSheet(
-                  type: GdsBottomSheetType.twoButton,
-                  title: '앨범명 변경',
-                  onClose: closeNameEditor,
-                  primaryLabel: '변경하기',
-                  secondaryLabel: '닫기',
-                  onPrimaryTap: () => onPrimaryTap(),
-                  onSecondaryTap: closeNameEditor,
-                  child: GdsTextField(
-                    controller: editController,
-                    focusNode: editFocusNode,
-                    size: GdsTextFieldSize.medium,
-                  ),
-                );
-
-                bottomSheet.open(context).whenComplete(disposeNameEditor);
-              } else {
-                final modal = GdsModal(
-                  title: '앨범명 변경',
-                  primaryLabel: '변경하기',
-                  secondaryLabel: '닫기',
-                  onPrimary: () => onPrimaryTap(),
-                  onSecondary: closeNameEditor,
-                  onClose: closeNameEditor,
-                  body: GdsTextField(
-                    controller: editController,
-                    focusNode: editFocusNode,
-                    size: GdsTextFieldSize.medium,
-                  ),
-                );
-
-                modal.open(context, isBarrierDismissible: true).whenComplete(disposeNameEditor);
-              }
-            },
+            onEditTap: () => showAlbumEdit(context, album, ref),
           ),
         );
       },

--- a/lib/presentation/album_edit/widget/album_edit.dart
+++ b/lib/presentation/album_edit/widget/album_edit.dart
@@ -6,7 +6,7 @@ import 'package:grimity/domain/entity/album.dart';
 import 'package:grimity/presentation/album_edit/provider/album_edit_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-Future<String> showAlbumEdit(
+Future<void> showAlbumEdit(
   BuildContext context,
   Album album,
   WidgetRef ref, {
@@ -60,7 +60,6 @@ Future<String> showAlbumEdit(
     );
 
     await bottomSheet.open(context).whenComplete(disposeNameEditor);
-    return editController.text.trim();
   } else {
     final modal = GdsModal(
       title: '앨범명 변경',
@@ -77,6 +76,5 @@ Future<String> showAlbumEdit(
     );
 
     await modal.open(context, isBarrierDismissible: true).whenComplete(disposeNameEditor);
-    return editController.text.trim();
   }
 }

--- a/lib/presentation/album_edit/widget/album_edit.dart
+++ b/lib/presentation/album_edit/widget/album_edit.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:gds/gds.dart';
+import 'package:grimity/domain/entity/album.dart';
+import 'package:grimity/presentation/album_edit/provider/album_edit_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+Future<String> showAlbumEdit(
+  BuildContext context,
+  Album album,
+  WidgetRef ref, {
+  FutureOr<bool> Function(Album album)? onEdited,
+}) async {
+  final editController = TextEditingController(text: album.name);
+  final editFocusNode = FocusNode();
+
+  void closeNameEditor() {
+    editFocusNode.unfocus();
+    Navigator.pop(context);
+  }
+
+  void disposeNameEditor() {
+    editFocusNode.unfocus();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      editController.dispose();
+      editFocusNode.dispose();
+    });
+  }
+
+  Future<void> onPrimaryTap() async {
+    final editedName = editController.text.trim();
+    if (editedName == album.name.trim()) {
+      closeNameEditor();
+      return;
+    }
+
+    final editedAlbum = album.copyWith(name: editedName);
+    final didEdit =
+        await (onEdited?.call(editedAlbum) ?? ref.read(albumEditProvider.notifier).updateAlbum(editedAlbum));
+    if (didEdit) {
+      closeNameEditor();
+    }
+  }
+
+  if (context.isMobile) {
+    final bottomSheet = GdsBottomSheet(
+      type: GdsBottomSheetType.twoButton,
+      title: '앨범명 변경',
+      onClose: closeNameEditor,
+      primaryLabel: '변경하기',
+      secondaryLabel: '닫기',
+      onPrimaryTap: () => onPrimaryTap(),
+      onSecondaryTap: closeNameEditor,
+      child: GdsTextField(
+        controller: editController,
+        focusNode: editFocusNode,
+        size: GdsTextFieldSize.medium,
+      ),
+    );
+
+    await bottomSheet.open(context).whenComplete(disposeNameEditor);
+    return editController.text.trim();
+  } else {
+    final modal = GdsModal(
+      title: '앨범명 변경',
+      primaryLabel: '변경하기',
+      secondaryLabel: '닫기',
+      onPrimary: () => onPrimaryTap(),
+      onSecondary: closeNameEditor,
+      onClose: closeNameEditor,
+      body: GdsTextField(
+        controller: editController,
+        focusNode: editFocusNode,
+        size: GdsTextFieldSize.medium,
+      ),
+    );
+
+    await modal.open(context, isBarrierDismissible: true).whenComplete(disposeNameEditor);
+    return editController.text.trim();
+  }
+}

--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -16,7 +16,7 @@ class AlbumEditAppBar extends ConsumerWidget {
       title: '앨범 편집',
       label: context.isMobile ? '저장' : '저장하기',
       onTitle: () {},
-      onBack: () => Navigator.pop(context),
+      onBack: context.pop,
       onSave: () async {
         final saved = await notifier.saveChanges();
         if (context.mounted && saved) {

--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -16,6 +16,7 @@ class AlbumEditAppBar extends ConsumerWidget {
       title: '앨범 편집',
       label: context.isMobile ? '저장' : '저장하기',
       onTitle: () {},
+      onBack: () => Navigator.pop(context),
       onSave: () async {
         final saved = await notifier.saveChanges();
         if (context.mounted && saved) {

--- a/lib/presentation/album_organize/album_organize_view.dart
+++ b/lib/presentation/album_organize/album_organize_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gds/gds.dart';
 
 class AlbumOrganizeView extends ConsumerWidget {
   const AlbumOrganizeView({
@@ -9,17 +10,17 @@ class AlbumOrganizeView extends ConsumerWidget {
     required this.albumOrganizeFabView,
   });
 
-  final PreferredSizeWidget albumOrganizeAppBar;
+  final Widget albumOrganizeAppBar;
   final Widget albumOrganizeBodyView;
   final Widget albumOrganizeFabView;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
+    return GdsScaffold(
       appBar: albumOrganizeAppBar,
       body: albumOrganizeBodyView,
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton: albumOrganizeFabView,
+      // floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      // floatingActionButton: albumOrganizeFabView,
     );
   }
 }

--- a/lib/presentation/album_organize/provider/album_organize_provider.dart
+++ b/lib/presentation/album_organize/provider/album_organize_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:grimity/app/service/toast_service.dart';
+import 'package:grimity/app/util/validator_util.dart';
 import 'package:grimity/domain/dto/album_request_params.dart';
 import 'package:grimity/domain/dto/feeds_request_param.dart';
 import 'package:grimity/domain/entity/album.dart';
@@ -28,6 +29,57 @@ class AlbumOrganize extends _$AlbumOrganize {
 
   void updateTargetAlbumId(String? id) {
     state = state.copyWith(targetAlbumId: id);
+  }
+
+  FutureOr<bool> updateAlbum(Album album) async {
+    if (state.uploading) {
+      ToastService.showFailure('처리 중입니다. 잠시만 기다려주세요');
+      return false;
+    }
+
+    final name = album.name.trim();
+    if (!ValidatorUtil.isValidAlbumName(name)) {
+      ToastService.showFailure('앨범명 최대 15자까지만 가능해요');
+      return false;
+    }
+
+    final hasDuplicateName = state.userAlbums.any(
+      (item) => item.id != album.id && item.name.trim() == name,
+    );
+    if (hasDuplicateName) {
+      ToastService.showFailure('중복된 이름은 사용하실 수 없어요');
+      return false;
+    }
+
+    _setUploading(true);
+
+    try {
+      final result = await updateAlbumUseCase.execute(
+        UpdateAlbumWithIdRequestParam(
+          id: album.id,
+          param: UpdateAlbumRequestParam(name: name),
+        ),
+      );
+
+      return result.fold(
+        onSuccess: (_) {
+          final updatedAlbum = album.copyWith(name: name);
+          final updatedAlbums = state.userAlbums.map((item) => item.id == album.id ? updatedAlbum : item).toList();
+          state = state.copyWith(
+            userAlbums: updatedAlbums,
+            user: state.user.copyWith(albums: updatedAlbums),
+          );
+          ToastService.showSuccess('앨범명이 변경되었어요');
+          return true;
+        },
+        onFailure: (_) {
+          ToastService.showFailure('앨범명 변경에 실패했어요');
+          return false;
+        },
+      );
+    } finally {
+      _setUploading(false);
+    }
   }
 
   void _setUploading(bool uploading) {
@@ -64,11 +116,11 @@ class AlbumOrganize extends _$AlbumOrganize {
 
       final isSuccess = result.fold(
         onSuccess: (value) {
-          ToastService.showSuccess('삭제가 완료되었습니다');
+          ToastService.showSuccess('선택한 그림을 삭제했어요');
           return true;
         },
         onFailure: (e) {
-          ToastService.showFailure('삭제가 실패되었습니다');
+          ToastService.showFailure('선택한 그림 삭제에 실패했어요');
           return false;
         },
       );
@@ -113,11 +165,11 @@ class AlbumOrganize extends _$AlbumOrganize {
 
       final isSuccess = result.fold(
         onSuccess: (value) {
-          ToastService.showSuccess('이동이 완료되었습니다');
+          ToastService.showSuccess('선택한 그림을 이동했어요');
           return true;
         },
         onFailure: (e) {
-          ToastService.showFailure('이동이 실패되었습니다');
+          ToastService.showFailure('선택한 그림 이동에 실패했어요');
           return false;
         },
       );

--- a/lib/presentation/album_organize/view/album_organize_body_view.dart
+++ b/lib/presentation/album_organize/view/album_organize_body_view.dart
@@ -195,7 +195,7 @@ class AlbumOrganizeBodyView extends HookConsumerWidget with AlbumOrganizeMixin {
                     if (context.isMobile) {
                       final bottomSheet = GdsBottomSheet(
                         type: GdsBottomSheetType.twoButton,
-                        title: '앨범명 변경',
+                        title: '앨범 이동',
                         primaryLabel: '이동하기',
                         secondaryLabel: '닫기',
                         onPrimaryTap: onPrimaryTap,
@@ -207,7 +207,7 @@ class AlbumOrganizeBodyView extends HookConsumerWidget with AlbumOrganizeMixin {
                       bottomSheet.open(context);
                     } else {
                       final modal = GdsModal(
-                        title: '앨범명 변경',
+                        title: '앨범 이동',
                         primaryLabel: '이동하기',
                         secondaryLabel: '닫기',
                         onPrimary: onPrimaryTap,

--- a/lib/presentation/album_organize/view/album_organize_body_view.dart
+++ b/lib/presentation/album_organize/view/album_organize_body_view.dart
@@ -1,17 +1,18 @@
 import 'package:dynamic_height_list_view/dynamic_height_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/app/config/app_typeface.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/extension/build_context_extension.dart';
+import 'package:grimity/app/service/toast_service.dart';
 import 'package:grimity/domain/entity/feed.dart';
+import 'package:grimity/presentation/album_edit/widget/album_edit.dart';
 import 'package:grimity/presentation/album_organize/provider/album_feed_data_provider.dart';
 import 'package:grimity/presentation/album_organize/provider/album_organize_provider.dart';
 import 'package:grimity/presentation/common/widget/grimity_infinite_scroll_pagination.dart';
-import 'package:grimity/presentation/common/widget/grimity_selectable_image_feed.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:skeletonizer/skeletonizer.dart';
+import 'package:collection/collection.dart';
 
 class AlbumOrganizeBodyView extends HookConsumerWidget with AlbumOrganizeMixin {
   const AlbumOrganizeBodyView({super.key});
@@ -20,45 +21,210 @@ class AlbumOrganizeBodyView extends HookConsumerWidget with AlbumOrganizeMixin {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
+    final colors = context.gdsColors;
     final state = albumOrganizeState(ref);
     final user = state.user;
-    final currentAlbumId = state.currentAlbumId;
     final userAlbums = state.userAlbums;
+    final currentAlbumId = state.currentAlbumId;
+    final currentAlbum = userAlbums.firstWhereOrNull((e) => e.id == currentAlbumId);
     final albumFeeds = ref.watch(albumFeedDataProvider(user.id, currentAlbumId));
 
-    return GrimityInfiniteScrollPagination(
-      isEnabled: user.id.isNotEmpty && albumFeeds.valueOrNull?.nextCursor != null,
-      onLoadMore: ref.read(albumFeedDataProvider(user.id, currentAlbumId).notifier).loadMore,
-      child: CustomScrollView(
-        slivers: [
-          SliverPadding(
-            padding: EdgeInsets.only(top: 24, left: 16, right: 16),
-            sliver: SliverToBoxAdapter(
-              child: Text(
-                currentAlbumId == null ? '전체 앨범' : userAlbums.firstWhere((e) => e.id == currentAlbumId).name,
-                style: AppTypeface.subTitle1.copyWith(color: AppColor.gray800),
+    return Stack(
+      children: [
+        GrimityInfiniteScrollPagination(
+          isEnabled: user.id.isNotEmpty && albumFeeds.valueOrNull?.nextCursor != null,
+          onLoadMore: ref.read(albumFeedDataProvider(user.id, currentAlbumId).notifier).loadMore,
+          child: SingleChildScrollView(
+            child: Padding(
+              padding:
+                  context.isMobile
+                      ? EdgeInsets.all(GdsSpacing.spacing16)
+                      : EdgeInsets.only(
+                        top: GdsSpacing.spacing24,
+                        left: GdsSpacing.spacing20,
+                        right: GdsSpacing.spacing20,
+                        bottom: GdsSpacing.spacing20,
+                      ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: context.isMobile ? GdsSpacing.spacing16 : GdsSpacing.spacing12,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        currentAlbum?.name ?? '전체 앨범',
+                        style:
+                            context.isMobile
+                                ? GdsTypography.title2.copyWith(color: colors.text.grayBold)
+                                : GdsTypography.title1.copyWith(color: colors.text.grayBold),
+                      ),
+                      GdsTextButton(
+                        text: '앨범명 변경',
+                        size: GdsTextButtonSize.regular,
+                        enabled: currentAlbum != null,
+                        variant: GdsTextButtonVariant.assistive,
+                        trailingIcon: GdsIcon.pen2Outline,
+                        onPressed:
+                            () => showAlbumEdit(
+                              context,
+                              currentAlbum!,
+                              ref,
+                              onEdited: albumOrganizeNotifier(ref).updateAlbum,
+                            ),
+                      ),
+                    ],
+                  ),
+                  albumFeeds.when(
+                    data: (data) => _buildSelectableFeedGrid(context, ref, feeds: data.feeds),
+                    loading:
+                        () => _buildSelectableFeedGrid(
+                          context,
+                          ref,
+                          isSkeleton: true,
+                          feeds: Feed.createEmptyList(context),
+                        ),
+                    error:
+                        (error, stackTrace) => GrimityStateView.error(
+                          onTap: () => ref.invalidate(albumFeedDataProvider(user.id, currentAlbumId)),
+                        ),
+                  ),
+                ],
               ),
             ),
           ),
-          albumFeeds.when(
-            data: (data) => _buildSelectableFeedGrid(context, ref, feeds: data.feeds),
-            loading:
-                () => _buildSelectableFeedGrid(
-                  context,
-                  ref,
-                  isSkeleton: true,
-                  feeds: Feed.createEmptyList(context),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: EdgeInsets.only(bottom: GdsSpacing.spacing24),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: GdsSpacing.spacing16,
+              children: [
+                GdsSolidButton(
+                  text: '선택 삭제',
+                  size: GdsSolidButtonSize.large,
+                  enabled: albumFeeds.valueOrNull?.feeds.isNotEmpty ?? false,
+                  rounded: true,
+                  leadingIcon: GdsIcon.trash,
+                  onPressed: () {
+                    if (state.ids.isEmpty) {
+                      ToastService.show('삭제할 그림을 선택해주세요', GdsToastType.info);
+                      return;
+                    }
+
+                    final alert = GdsAlert(
+                      type: GdsAlertType.content,
+                      size: context.isMobile ? GdsAlertSize.md : GdsAlertSize.xl,
+                      title: '선택한 그림을 삭제할까요?',
+                      description: '삭제 이후 되돌릴 수 없어요',
+                      primaryLabel: '삭제하기',
+                      secondaryLabel: '아니요',
+                      onPrimaryTap: () {
+                        Navigator.pop(context);
+                        albumOrganizeNotifier(ref).deleteFeeds();
+                      },
+                      onSecondaryTap: () => Navigator.pop(context),
+                    );
+
+                    alert.open(context);
+                  },
                 ),
-            error: (error, stackTrace) {
-              return SliverToBoxAdapter(
-                child: GrimityStateView.error(
-                  onTap: () => ref.invalidate(albumFeedDataProvider(user.id, currentAlbumId)),
+                GdsSolidButton(
+                  text: '앨범 이동',
+                  size: GdsSolidButtonSize.large,
+                  enabled: albumFeeds.valueOrNull?.feeds.isNotEmpty ?? false,
+                  rounded: true,
+                  leadingIcon: GdsIcon.forward,
+                  onPressed: () {
+                    if (state.ids.isEmpty) {
+                      ToastService.show('이동할 그림을 선택해주세요', GdsToastType.info);
+                      return;
+                    }
+
+                    String? selectedAlbumId = '';
+
+                    final child = StatefulBuilder(
+                      builder: (context, setState) {
+                        return Column(
+                          mainAxisSize: MainAxisSize.min,
+                          spacing: GdsSpacing.spacing8,
+                          children: [
+                            GdsListItem.optionCard(
+                              text: '전체 앨범',
+                              state:
+                                  currentAlbum != null
+                                      ? selectedAlbumId == null
+                                          ? GdsListItemState.pressed
+                                          : GdsListItemState.enabled
+                                      : GdsListItemState.disabled,
+                              onTap: currentAlbum != null ? () => setState(() => selectedAlbumId = null) : () => {},
+                            ),
+                            ...userAlbums.map(
+                              (album) => GdsListItem.optionCard(
+                                text: album.name,
+                                state:
+                                    album.id == currentAlbumId
+                                        ? GdsListItemState.disabled
+                                        : selectedAlbumId == album.id
+                                        ? GdsListItemState.pressed
+                                        : GdsListItemState.enabled,
+                                onTap:
+                                    album.id == currentAlbumId
+                                        ? () => {}
+                                        : () => setState(() => selectedAlbumId = album.id),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    );
+
+                    onPrimaryTap() {
+                      if (selectedAlbumId == '' || selectedAlbumId == currentAlbumId) {
+                        ToastService.show('이동할 앨범을 선택해주세요', GdsToastType.info);
+                        return;
+                      }
+
+                      albumOrganizeNotifier(ref).updateTargetAlbumId(selectedAlbumId);
+                      Navigator.pop(context);
+                      albumOrganizeNotifier(ref).moveFeeds();
+                    }
+
+                    if (context.isMobile) {
+                      final bottomSheet = GdsBottomSheet(
+                        type: GdsBottomSheetType.twoButton,
+                        title: '앨범명 변경',
+                        primaryLabel: '이동하기',
+                        secondaryLabel: '닫기',
+                        onPrimaryTap: onPrimaryTap,
+                        onSecondaryTap: () => Navigator.pop(context),
+                        onClose: () => Navigator.pop(context),
+                        child: child,
+                      );
+
+                      bottomSheet.open(context);
+                    } else {
+                      final modal = GdsModal(
+                        title: '앨범명 변경',
+                        primaryLabel: '이동하기',
+                        secondaryLabel: '닫기',
+                        onPrimary: onPrimaryTap,
+                        onSecondary: () => Navigator.pop(context),
+                        onClose: () => Navigator.pop(context),
+                        body: child,
+                      );
+
+                      modal.open(context);
+                    }
+                  },
                 ),
-              );
-            },
+              ],
+            ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -68,33 +234,54 @@ class AlbumOrganizeBodyView extends HookConsumerWidget with AlbumOrganizeMixin {
     bool isSkeleton = false,
     required List<Feed> feeds,
   }) {
+    final colors = context.gdsColors;
     final state = albumOrganizeState(ref);
 
-    return SliverPadding(
-      padding: EdgeInsets.only(
-        top: 16,
-        left: 16,
-        right: 16,
-        bottom: 20,
-      ),
-      sliver: SliverDynamicHeightGridView(
-        crossAxisCount: context.feedRowCount,
-        crossAxisSpacing: 12,
-        mainAxisSpacing: 20,
-        itemCount: feeds.length,
-        builder: (context, index) {
-          final feed = feeds[index];
-          final containFeed = state.ids.contains(feed.id);
-          final child = GrimitySelectableImageFeed(
-            feed: feed,
-            authorName: state.user.name,
-            selected: containFeed,
-            onToggleSelected: () => albumOrganizeNotifier(ref).toggleFeed(feed.id),
-          );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: GdsSpacing.spacing12,
+      children: [
+        Row(
+          spacing: GdsSpacing.spacing2,
+          children: [
+            Text('그림', style: GdsTypography.label4.copyWith(color: colors.surface.grayNormal)),
+            Text('${feeds.length}', style: GdsTypography.label4.copyWith(color: colors.surface.grayBold)),
+          ],
+        ),
+        if (feeds.isNotEmpty) ...[
+          DynamicHeightGridView(
+            crossAxisCount: context.feedRowCount,
+            crossAxisSpacing: GdsSpacing.spacing16,
+            mainAxisSpacing: GdsSpacing.spacing16,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: feeds.length,
+            builder: (context, index) {
+              final feed = feeds[index];
+              final containFeed = state.ids.contains(feed.id);
+              final child = GdsAlbumCard(
+                width: double.infinity,
+                title: feed.title,
+                nickname: feed.author?.name ?? state.user.name,
+                heartCount: feed.likeCount,
+                viewCount: feed.viewCount,
+                imageUrl: feed.thumbnail ?? '',
+                type: GdsAlbumCardType.check,
+                state: containFeed ? GdsAlbumCardState.checked : GdsAlbumCardState.defaultType,
+                onTap: () => albumOrganizeNotifier(ref).toggleFeed(feed.id),
+              );
 
-          return isSkeleton ? Skeletonizer(child: child) : child;
-        },
-      ),
+              return isSkeleton ? Skeletonizer(child: child) : child;
+            },
+          ),
+        ] else ...[
+          GdsEmptyState(
+            size: context.isMobile ? GdsEmptyStateSize.md : GdsEmptyStateSize.xl,
+            icon: GdsIcon.resultNull,
+            title: '업로드한 그림이 없어요',
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/presentation/album_organize/widget/album_organize_app_bar.dart
+++ b/lib/presentation/album_organize/widget/album_organize_app_bar.dart
@@ -1,33 +1,11 @@
-import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/app/config/app_theme.dart';
-import 'package:grimity/app/config/app_typeface.dart';
-import 'package:grimity/gen/assets.gen.dart';
-import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
+import 'package:flutter/widgets.dart';
+import 'package:grimity/presentation/common/widget/navigation/grimity_title_top_navigation.dart';
 
-class AlbumOrganizeAppBar extends StatelessWidget implements PreferredSizeWidget {
+class AlbumOrganizeAppBar extends StatelessWidget {
   const AlbumOrganizeAppBar({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      toolbarHeight: AppTheme.kToolbarHeight.height,
-      leading: Center(
-        child: GrimityGesture(
-          onTap: () => context.pop(),
-          child: Assets.icons.icon.close.svg(width: 24, height: 24),
-        ),
-      ),
-      title: Text('그림 정리', style: AppTypeface.subTitle3),
-      titleSpacing: 0,
-      bottom: const PreferredSize(
-        preferredSize: Size.fromHeight(1),
-        child: Divider(height: 1, color: AppColor.gray300),
-      ),
-    );
+    return GrimityTitleTopNavigation(title: '그림 정리');
   }
-
-  @override
-  Size get preferredSize => AppTheme.kToolbarHeight;
 }

--- a/lib/presentation/common/widget/navigation/grimity_title_top_navigation.dart
+++ b/lib/presentation/common/widget/navigation/grimity_title_top_navigation.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gds/gds.dart';
+import 'package:grimity/app/config/app_router.dart';
+import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
+
+class GrimityTitleTopNavigation extends ConsumerWidget {
+  const GrimityTitleTopNavigation({
+    super.key,
+    required this.title,
+    this.onBack,
+    this.onSearch,
+    this.onAvatar,
+    this.onNotification,
+  });
+
+  final String title;
+  final VoidCallback? onBack;
+  final VoidCallback? onSearch;
+  final VoidCallback? onAvatar;
+  final VoidCallback? onNotification;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final avatarImage = ref.watch(userAuthProvider.select((user) => user?.image));
+    final hasNotification = ref.watch(userAuthProvider.select((user) => user?.hasNotification ?? false));
+
+    return GdsTopNavigation.title(
+      title: title,
+      onBack:
+          onBack ??
+          () {
+            Navigator.maybePop(context);
+          },
+      onSearch:
+          onSearch ??
+          () {
+            const SearchRoute().push(context);
+          },
+      onAvatar:
+          onAvatar ??
+          () {
+            Scaffold.maybeOf(context)?.openEndDrawer();
+          },
+      onNotification:
+          onNotification ??
+          () {
+            const NotificationRoute().push(context);
+          },
+      avatarImageUrl: avatarImage,
+      hasNotification: hasNotification,
+    );
+  }
+}

--- a/lib/presentation/profile/view/profile_feed_tab_view.dart
+++ b/lib/presentation/profile/view/profile_feed_tab_view.dart
@@ -55,11 +55,9 @@ class ProfileFeedTabView extends HookConsumerWidget {
               ],
             ),
           ),
-          // 해당 앨범의 피드 갯수가 0개가 아닐때 표시
-          if (selectedAlbumFeedCount != 0)
-            SliverToBoxAdapter(
-              child: _buildSortHeader(context, ref, selectedAlbumId, selectedAlbumFeedCount, viewType),
-            ),
+          SliverToBoxAdapter(
+            child: _buildSortHeader(context, ref, selectedAlbumId, selectedAlbumFeedCount, viewType),
+          ),
           SliverToBoxAdapter(
             child: feedsAsync.when(
               data: (data) => _buildFeedGrid(context, data.feeds, viewType),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      resolved-ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
+      resolved-ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
+      resolved-ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
+      resolved-ref: d7227a93c85fb5677fe9f8368f9a0d089e710bd4
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
## 간단 요약
- 앨범 정리 화면(Album Organize)을 디자인 시스템 컴포넌트 및 상수 이식
- 선택 삭제/앨범 이동/앨범명 변경 동작 연결
- `GdsTopNavigation.title` 공통 래퍼 `GrimityTitleTopNavigation` 추가
