### PR TITLE
feat: 알림 화면 GDS 테마 적용 및 빈 상태 추가

### DIFF
--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -24,9 +24,6 @@ class AlbumEditAppBar extends ConsumerWidget {
         }
       },
       saveEnabled: notifier.canSave,
-      onBack: () {
-        context.pop();
-      },
     );
   }
 }

--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -23,8 +23,8 @@ class AlbumEditAppBar extends ConsumerWidget {
           context.pop();
         }
       },
-      saveEnabled: notifier.canSave, 
-      onBack: () {  
+      saveEnabled: notifier.canSave,
+      onBack: () {
         context.pop();
       },
     );

--- a/lib/presentation/album_edit/widget/album_edit_app_bar.dart
+++ b/lib/presentation/album_edit/widget/album_edit_app_bar.dart
@@ -22,7 +22,10 @@ class AlbumEditAppBar extends ConsumerWidget {
           context.pop();
         }
       },
-      saveEnabled: notifier.canSave,
+      saveEnabled: notifier.canSave, 
+      onBack: () {  
+        context.pop();
+      },
     );
   }
 }

--- a/lib/presentation/common/widget/grimity_state_view.dart
+++ b/lib/presentation/common/widget/grimity_state_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_button.dart';
@@ -197,6 +197,8 @@ class GrimityStateView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.gdsColors;
+
     return Align(
       alignment: Alignment.topCenter,
       child: Padding(
@@ -212,13 +214,13 @@ class GrimityStateView extends StatelessWidget {
                 if (title != null)
                   Text(
                     title!,
-                    style: AppTypeface.subTitle3.copyWith(color: AppColor.gray700),
+                    style: AppTypeface.subTitle3.copyWith(color: colors.text.grayBold),
                     textAlign: TextAlign.center,
                   ),
                 if (subTitle != null)
                   Text(
                     subTitle!,
-                    style: AppTypeface.label2.copyWith(color: AppColor.gray600),
+                    style: AppTypeface.label2.copyWith(color: colors.text.graySubtle),
                     textAlign: TextAlign.center,
                   ),
               ],

--- a/lib/presentation/notification/notification_page.dart
+++ b/lib/presentation/notification/notification_page.dart
@@ -19,13 +19,10 @@ class NotificationPage extends ConsumerWidget {
       notificationAppBar: NotificationAppBar(),
       notificationBody: notificationAsync.when(
         data:
-            (notifications) =>
-                notifications.isEmpty
-                    ? GrimityStateView.resultNull(
-                      title: '새로운 알림이 없어요',
-                      subTitle: '내 글의 댓글와 좋아요, 다른 작가의 활동 등\n새로운 소식을 알려드려요',
-                    )
-                    : NotificationBodyView(notifications: notifications),
+            (notifications) => NotificationBodyView(
+              notifications: notifications,
+              isEmpty: notifications.isEmpty,
+            ),
         loading: () => Skeletonizer(child: NotificationBodyView(notifications: Notification.emptyList)),
         error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(notificationDataProvider)),
       ),

--- a/lib/presentation/notification/notification_view.dart
+++ b/lib/presentation/notification/notification_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gds/gds.dart';
 
 class NotificationView extends ConsumerWidget {
   const NotificationView({super.key, required this.notificationAppBar, required this.notificationBody});
@@ -9,6 +10,10 @@ class NotificationView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(appBar: notificationAppBar, body: notificationBody);
+    return Scaffold(
+      backgroundColor: context.gdsColors.bg.primary,
+      appBar: notificationAppBar,
+      body: notificationBody,
+    );
   }
 }

--- a/lib/presentation/notification/view/notification_body_view.dart
+++ b/lib/presentation/notification/view/notification_body_view.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
+import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/notification/provider/notification_data_provider.dart';
 import 'package:grimity/domain/entity/notification.dart';
@@ -9,13 +10,17 @@ import 'package:grimity/presentation/notification/widget/notification_action_but
 import 'package:grimity/presentation/notification/widget/notification_widget.dart';
 
 class NotificationBodyView extends ConsumerWidget {
-  const NotificationBodyView({super.key, required this.notifications});
+  const NotificationBodyView({super.key, required this.notifications, this.isEmpty = false});
 
   final List<Notification> notifications;
+  final bool isEmpty;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(notificationDataProvider.notifier);
+    final colors = context.gdsColors;
+    final listDividerColor = colors.border.graySubtle;
+    final actionDividerColor = colors.border.graySubtle;
 
     return CustomScrollView(
       slivers: [
@@ -31,7 +36,7 @@ class NotificationBodyView extends ConsumerWidget {
                   icon: Assets.icons.icon.eye,
                 ),
                 Gap(8),
-                VerticalDivider(color: AppColor.gray300, width: 1),
+                Container(width: 1, height: 24, color: actionDividerColor),
                 Gap(8),
                 NotificationActionButton(
                   title: '전체 삭제',
@@ -42,15 +47,41 @@ class NotificationBodyView extends ConsumerWidget {
             ),
           ),
         ),
-        SliverList.separated(
-          itemBuilder: (context, index) {
-            final notification = notifications[index];
+        if (isEmpty)
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 72),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  GdsIcon.alarmDark.build(width: 60, height: 60),
+                  const Gap(16),
+                  Text(
+                    '새로운 알림이 없어요',
+                    style: AppTypeface.subTitle1.copyWith(color: colors.text.grayBold),
+                    textAlign: TextAlign.center,
+                  ),
+                  const Gap(12),
+                  Text(
+                    '내 글의 댓글와 좋아요, 다른 작가의 활동 등\n새로운 소식을 알려드려요',
+                    style: AppTypeface.label3.copyWith(color: colors.text.grayBold, height: 1.6),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          )
+        else
+          SliverList.separated(
+            itemBuilder: (context, index) {
+              final notification = notifications[index];
 
-            return NotificationWidget(notification: notification);
-          },
-          separatorBuilder: (context, index) => Divider(height: 1, color: AppColor.gray300),
-          itemCount: notifications.length,
-        ),
+              return NotificationWidget(notification: notification);
+            },
+            separatorBuilder: (context, index) => Divider(height: 1, color: listDividerColor),
+            itemCount: notifications.length,
+          ),
       ],
     );
   }

--- a/lib/presentation/notification/widget/notification_action_button.dart
+++ b/lib/presentation/notification/widget/notification_action_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/gen/assets.gen.dart';
 import 'package:grimity/presentation/common/widget/grimity_gesture.dart';
@@ -14,21 +14,23 @@ class NotificationActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.gdsColors;
+
     return GrimityGesture(
       onTap: onTap,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
+          Text(title, style: AppTypeface.label1.copyWith(color: colors.text.graySubtler)),
+          Gap(6),
           icon.svg(
             width: 16,
             height: 16,
             colorFilter: ColorFilter.mode(
-              AppColor.gray500,
+              colors.icon.graySubtler,
               BlendMode.srcIn,
             ),
           ),
-          Gap(6),
-          Text(title, style: AppTypeface.caption2.copyWith(color: AppColor.gray700)),
         ],
       ),
     );

--- a/lib/presentation/notification/widget/notification_app_bar.dart
+++ b/lib/presentation/notification/widget/notification_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/config/app_router.dart';
 import 'package:grimity/app/config/app_theme.dart';
 import 'package:grimity/app/config/app_typeface.dart';
@@ -11,20 +11,36 @@ class NotificationAppBar extends StatelessWidget implements PreferredSizeWidget 
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.gdsColors;
+
     return AppBar(
+      backgroundColor: colors.bg.primary,
+      surfaceTintColor: colors.bg.primary,
+      foregroundColor: colors.icon.grayBold,
+      iconTheme: IconThemeData(color: colors.icon.grayBold),
       toolbarHeight: AppTheme.kToolbarHeight.height,
-      title: Text('알림', style: AppTypeface.subTitle3),
+      leading: Center(
+        child: GrimityGesture(
+          onTap: () => Navigator.of(context).maybePop(),
+          child: Assets.icons.icon.chevronLeftThick.svg(
+            width: 24,
+            height: 24,
+            colorFilter: ColorFilter.mode(colors.icon.grayBold, BlendMode.srcIn),
+          ),
+        ),
+      ),
+      title: Text('알림', style: AppTypeface.subTitle3.copyWith(color: colors.text.grayBold)),
       titleSpacing: 0,
       actions: [
         GrimityGesture(
           onTap: () => SettingRoute().push(context),
-          child: Assets.icons.icon.setting.svg(width: 24, height: 24),
+          child: Assets.icons.icon.setting.svg(
+            width: 24,
+            height: 24,
+            colorFilter: ColorFilter.mode(colors.icon.grayBold, BlendMode.srcIn),
+          ),
         ),
       ],
-      bottom: const PreferredSize(
-        preferredSize: Size.fromHeight(1),
-        child: Divider(height: 1, color: AppColor.gray300),
-      ),
     );
   }
 

--- a/lib/presentation/notification/widget/notification_widget.dart
+++ b/lib/presentation/notification/widget/notification_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Notification;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:grimity/app/config/app_color.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/app/config/app_typeface.dart';
 import 'package:grimity/app/extension/date_time_extension.dart';
 import 'package:grimity/app/linking/url_handler.dart';
@@ -19,6 +19,7 @@ class NotificationWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(notificationDataProvider.notifier);
+    final colors = context.gdsColors;
 
     return InkWell(
       onTap: () {
@@ -36,12 +37,12 @@ class NotificationWidget extends ConsumerWidget {
             Expanded(
               child: GrimityUserProfile.fromBuilder(
                 imageUrl: notification.image ?? '',
-                titleBuilder: () => _buildNotificationText(notification.message),
+                titleBuilder: () => _buildNotificationText(context, notification.message),
                 subTitleBuilder:
                     () => Text(
                       notification.createdAt.toRelativeTime(),
                       style: AppTypeface.caption2.copyWith(
-                        color: AppColor.gray600.withValues(alpha: notification.isRead ? 0.5 : 1.0),
+                        color: colors.text.graySubtle.withValues(alpha: notification.isRead ? 0.5 : 1.0),
                       ),
                     ),
               ),
@@ -52,7 +53,7 @@ class NotificationWidget extends ConsumerWidget {
               child: Assets.icons.icon.close.svg(
                 width: 20,
                 height: 20,
-                colorFilter: ColorFilter.mode(AppColor.gray500, BlendMode.srcIn),
+                colorFilter: ColorFilter.mode(colors.icon.graySubtle, BlendMode.srcIn),
               ),
             ),
           ],
@@ -65,9 +66,9 @@ class NotificationWidget extends ConsumerWidget {
   /// - 문장에 "님이"가 있을 경우: 마지막 "님이" 앞까지를 닉네임으로 인식하여 볼드 처리
   /// - 문장에 "…에 좋아요가" 패턴이 있을 경우: "에 좋아요가" 앞의 대상을 추출하여 볼드 처리
   /// - 두 패턴이 없으면: 전체 문자열을 일반 Text로 반환
-  Widget _buildNotificationText(String message) {
+  Widget _buildNotificationText(BuildContext context, String message) {
     final styleBase = AppTypeface.label3.copyWith(
-      color: AppColor.gray800.withValues(alpha: notification.isRead ? 0.5 : 1.0),
+      color: context.gdsColors.text.grayBold.withValues(alpha: notification.isRead ? 0.5 : 1.0),
     );
     final styleBold = styleBase.copyWith(fontWeight: FontWeight.bold);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
-      resolved-ref: e4a6b1da8e25a1635e815cedad8541941646e8bd
+      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1589,10 +1589,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1613,10 +1613,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2306,10 +2306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- notification 화면 컴포넌트들을 gds 토큰 기반 색상/타이포로 마이그레이션
- 알림 없음 상태에 `GdsIcon.alarmDark` 일러스트와 안내 텍스트 추가
- `GrimityStateView`를 gds 컬러 토큰으로 전환
- `AlbumEditAppBar`에 `onBack` 콜백 주입
- gds 의존성 업그레이드 (`alarm_dark` 아이콘 포함)

## Test plan
- [ ] 알림 페이지 진입 시 항목이 비어 있을 때 알람 일러스트 + 안내 문구가 정상 표시되는지 확인
- [ ] 알림이 있을 때 리스트와 디바이더 색상이 다크 테마 토큰을 따르는지 확인
- [ ] 전체 읽음 / 전체 삭제 버튼 동작 확인
- [ ] 앨범 편집 화면 뒤로가기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)