### PR TITLE
feat: 차단 목록 화면에 디자인 시스템 적용

### DIFF
--- a/lib/domain/entity/user.dart
+++ b/lib/domain/entity/user.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/album.dart';
 import 'package:grimity/domain/entity/link.dart';
 
@@ -8,6 +9,8 @@ part 'user.g.dart';
 
 @freezed
 abstract class User with _$User {
+  const User._();
+
   const factory User({
     required String id,
     required String name,
@@ -31,10 +34,16 @@ abstract class User with _$User {
     bool? isBlocking,
   }) = _User;
 
+  /// '@'가 붙은 형태의 핸들 반환
+  String get handle => '@$url';
+
+  /// [GdsPersonAvatar] 형태로 아바타 인스턴스 반환
+  GdsPersonAvatar get personAvatar => GdsPersonAvatar(imageUrl: image);
+
   factory User.empty() => const User(
     id: '',
+    url: 'lorem_ipsum',
     name: 'Lorem ipsum',
-    url: '',
     followerCount: 0,
     followingCount: 0,
     feedCount: 0,
@@ -45,5 +54,9 @@ abstract class User with _$User {
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
-  static List<User> get emptyList => [User.empty(), User.empty(), User.empty()];
+  static List<User> get emptyList => [
+    User.empty(),
+    User.empty(),
+    User.empty(),
+  ];
 }

--- a/lib/domain/entity/user.dart
+++ b/lib/domain/entity/user.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/album.dart';
 import 'package:grimity/domain/entity/link.dart';
 
@@ -36,9 +35,6 @@ abstract class User with _$User {
 
   /// '@'가 붙은 형태의 핸들 반환
   String get handle => '@$url';
-
-  /// [GdsPersonAvatar] 형태로 아바타 인스턴스 반환
-  GdsPersonAvatar get personAvatar => GdsPersonAvatar(imageUrl: image);
 
   factory User.empty() => const User(
     id: '',

--- a/lib/presentation/block/blocked_users_page.dart
+++ b/lib/presentation/block/blocked_users_page.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/presentation/block/view/blocked_users_view.dart';
 import 'package:grimity/presentation/block/widget/blocked_users_app_bar.dart';
 
@@ -7,7 +8,7 @@ class BlockedUsersPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return GdsScaffold(
       appBar: BlockedUsersAppBar(),
       body: BlockedUsersView(),
     );

--- a/lib/presentation/block/view/blocked_users_view.dart
+++ b/lib/presentation/block/view/blocked_users_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/presentation/block/provider/blocked_users_data_provider.dart';
+import 'package:grimity/presentation/common/extension/user_ui_extension.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 

--- a/lib/presentation/block/view/blocked_users_view.dart
+++ b/lib/presentation/block/view/blocked_users_view.dart
@@ -42,13 +42,8 @@ class BlockedUsersView extends ConsumerWidget {
 
         if (users.isEmpty) {
           return Container(
-            padding: EdgeInsets.only(
-              top: GdsSpacing.spacing16,
-              left: GdsSpacing.spacing16,
-              right: GdsSpacing.spacing16,
-              bottom: GdsSpacing.spacing40,
-            ),
             alignment: Alignment.center,
+            padding: padding,
             child: GdsEmptyState(title: '차단한 작가가 없어요', icon: GdsIcon.warning),
           );
         }

--- a/lib/presentation/block/view/blocked_users_view.dart
+++ b/lib/presentation/block/view/blocked_users_view.dart
@@ -7,7 +7,29 @@ import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class BlockedUsersView extends ConsumerWidget {
-  const BlockedUsersView({super.key});
+  const BlockedUsersView({
+    super.key,
+    this.isModal = false,
+  });
+
+  /// 모달 여부에 따라 다른 레이아웃과 패딩을 적용할 여부
+  final bool isModal;
+
+  /// 페이지에서 사용할 때의 기본 패딩 정의
+  static EdgeInsets padding = EdgeInsets.only(
+    top: GdsSpacing.spacing16,
+    left: GdsSpacing.spacing16,
+    right: GdsSpacing.spacing16,
+    bottom: GdsSpacing.spacing40,
+  );
+
+  /// 모달에서 사용할 때의 별도의 패딩 정의
+  static EdgeInsets modalPadding = EdgeInsets.only(
+    top: GdsSpacing.spacing8,
+    left: GdsSpacing.spacing20,
+    right: GdsSpacing.spacing20,
+    bottom: GdsSpacing.spacing20,
+  );
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -30,23 +52,35 @@ class BlockedUsersView extends ConsumerWidget {
           );
         }
 
-        return BlockedUserListView(users: users);
+        return BlockedUserListView(users: users, isModal: isModal);
       },
-      loading: () => Skeletonizer(child: BlockedUserListView(users: User.emptyList)),
+      loading: () => Skeletonizer(child: BlockedUserListView(users: User.emptyList, isModal: isModal)),
       error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(blockedUsersDataProvider)),
     );
   }
 }
 
 class BlockedUserListView extends ConsumerWidget {
-  const BlockedUserListView({super.key, required this.users});
+  const BlockedUserListView({
+    super.key,
+    required this.users,
+    required this.isModal,
+  });
 
   final List<User> users;
+  final bool isModal;
+
+  /// 페이지에서 사용할 때의 기본 패딩 정의
+  static EdgeInsets padding = EdgeInsets.all(GdsSpacing.spacing16);
+
+  /// 모달에서 사용할 때의 별도의 패딩 정의
+  static EdgeInsets modalPadding = BlockedUsersView.modalPadding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ListView.builder(
-      padding: EdgeInsets.all(GdsSpacing.spacing16),
+      padding: isModal ? modalPadding : padding,
+      shrinkWrap: isModal ? true : false,
       itemCount: users.length,
       itemBuilder: (context, index) {
         final user = users[index];

--- a/lib/presentation/block/view/blocked_users_view.dart
+++ b/lib/presentation/block/view/blocked_users_view.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:gap/gap.dart';
+import 'package:gds/gds.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/presentation/block/provider/blocked_users_data_provider.dart';
-import 'package:grimity/presentation/common/widget/button/grimity_button.dart';
 import 'package:grimity/presentation/common/widget/grimity_state_view.dart';
-import 'package:grimity/presentation/common/widget/system/profile/grimity_user_profile.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class BlockedUsersView extends ConsumerWidget {
@@ -15,23 +13,27 @@ class BlockedUsersView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final blockedUsers = ref.watch(blockedUsersDataProvider);
 
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: blockedUsers.when(
-        data: (data) {
-          final users = data;
+    return blockedUsers.when(
+      data: (data) {
+        final users = data;
 
-          if (users.isEmpty) {
-            return GrimityStateView.resultNull(
-              subTitle: '아직 차단한 유저가 없어요',
-            );
-          }
+        if (users.isEmpty) {
+          return Container(
+            padding: EdgeInsets.only(
+              top: GdsSpacing.spacing16,
+              left: GdsSpacing.spacing16,
+              right: GdsSpacing.spacing16,
+              bottom: GdsSpacing.spacing40,
+            ),
+            alignment: Alignment.center,
+            child: GdsEmptyState(title: '차단한 작가가 없어요', icon: GdsIcon.warning),
+          );
+        }
 
-          return BlockedUserListView(users: users);
-        },
-        loading: () => Skeletonizer(child: BlockedUserListView(users: User.emptyList)),
-        error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(blockedUsersDataProvider)),
-      ),
+        return BlockedUserListView(users: users);
+      },
+      loading: () => Skeletonizer(child: BlockedUserListView(users: User.emptyList)),
+      error: (e, s) => GrimityStateView.error(onTap: () => ref.invalidate(blockedUsersDataProvider)),
     );
   }
 }
@@ -43,29 +45,22 @@ class BlockedUserListView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListView.separated(
+    return ListView.builder(
+      padding: EdgeInsets.all(GdsSpacing.spacing16),
       itemCount: users.length,
       itemBuilder: (context, index) {
         final user = users[index];
 
-        return Row(
-          children: [
-            Expanded(
-              child: GrimityUserProfile.fromString(
-                title: user.name,
-                imageUrl: user.image,
-              ),
-            ),
-            GrimityButton.round(
-              text: '차단 해제',
-              onTap: () => ref.read(blockedUsersDataProvider.notifier).unblockUser(user.id),
-              style: ButtonStyleType.line,
-            ),
-          ],
+        return GdsUserItem.id(
+          userId: user.handle,
+          nickName: user.name,
+          personAvatar: user.personAvatar,
+          secondaryActionButton: GdsOutlinedButton(
+            size: GdsOutlinedButtonSize.small,
+            text: '차단 해제',
+            onPressed: () => ref.read(blockedUsersDataProvider.notifier).unblockUser(user.id),
+          ),
         );
-      },
-      separatorBuilder: (context, index) {
-        return Gap(16);
       },
     );
   }

--- a/lib/presentation/block/widget/blocked_users_app_bar.dart
+++ b/lib/presentation/block/widget/blocked_users_app_bar.dart
@@ -1,19 +1,11 @@
-import 'package:flutter/material.dart';
-import 'package:grimity/app/config/app_color.dart';
-import 'package:grimity/app/config/app_theme.dart';
-import 'package:grimity/app/config/app_typeface.dart';
+import 'package:flutter/widgets.dart';
+import 'package:grimity/presentation/common/widget/navigation/grimity_title_top_navigation.dart';
 
-class BlockedUsersAppBar extends StatelessWidget implements PreferredSizeWidget {
+class BlockedUsersAppBar extends StatelessWidget {
   const BlockedUsersAppBar({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      title: Text('차단 목록', style: AppTypeface.subTitle3.copyWith(color: AppColor.primary4)),
-      titleSpacing: 0,
-    );
+    return GrimityTitleTopNavigation(title: '차단 목록');
   }
-
-  @override
-  Size get preferredSize => Size.fromHeight(AppTheme.kToolbarHeight.height);
 }

--- a/lib/presentation/block/widget/blocked_users_modal.dart
+++ b/lib/presentation/block/widget/blocked_users_modal.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+import 'package:gds/gds.dart';
+import 'package:grimity/presentation/block/view/blocked_users_view.dart';
+
+/// 차단한 사용자 목록을 모달 형태로 표시합니다.
+Future<T?> showBlockedUsersModal<T>(BuildContext context) {
+  final modal = GdsModal(
+    title: '차단',
+    body: BlockedUsersView(isModal: true),
+  );
+
+  return modal.open(context, isBarrierDismissible: true);
+}

--- a/lib/presentation/common/extension/user_ui_extension.dart
+++ b/lib/presentation/common/extension/user_ui_extension.dart
@@ -1,0 +1,6 @@
+import 'package:gds/gds.dart';
+import 'package:grimity/domain/entity/user.dart';
+
+extension UserUiExtension on User {
+  GdsPersonAvatar get personAvatar => GdsPersonAvatar(imageUrl: image);
+}

--- a/lib/presentation/profile/view/user_profile_view.dart
+++ b/lib/presentation/profile/view/user_profile_view.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
+import 'package:gds/gds.dart';
 import 'package:go_router/go_router.dart';
 import 'package:grimity/app/config/app_color.dart';
 import 'package:grimity/app/config/app_config.dart';
@@ -15,6 +16,7 @@ import 'package:grimity/domain/dto/chat_request_params.dart';
 import 'package:grimity/domain/entity/user.dart';
 import 'package:grimity/domain/usecase/me_usecases.dart';
 import 'package:grimity/gen/assets.gen.dart';
+import 'package:grimity/presentation/block/widget/blocked_users_modal.dart';
 import 'package:grimity/presentation/common/provider/user_auth_provider.dart';
 import 'package:grimity/presentation/common/widget/alert/grimity_dialog.dart';
 import 'package:grimity/presentation/common/widget/button/grimity_follow_button.dart';
@@ -138,7 +140,7 @@ class UserProfileView extends ConsumerWidget {
           title: '차단 목록',
           onTap: () {
             context.pop();
-            BlockedUsersRoute().push(context);
+            context.isMobile ? BlockedUsersRoute().push(context) : showBlockedUsersModal(context);
           },
         ),
       ] else ...[

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1114,7 +1114,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      resolved-ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1122,8 +1122,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/components"
-      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
-      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
+      resolved-ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1131,8 +1131,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/foundation"
-      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
-      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
+      resolved-ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"
@@ -1140,8 +1140,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/tokens"
-      ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
-      resolved-ref: "8c2a111bf48f6fb3acdb5a35c376bc1ccbef7574"
+      ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
+      resolved-ref: "1da381a5fb3094aed3aeda2b9fdb07b2b3419c7c"
       url: "https://github.com/Grimity/gds-flutter"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1589,10 +1589,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1613,10 +1613,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -2306,10 +2306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## 작업 내용

- 차단 목록 화면에 GDS 컴포넌트를 적용했습니다용.
  - `Scaffold`를 `GdsScaffold`로 교체
  - 앱바를 `GrimityTitleTopNavigation` 기반으로 변경
  - 차단 유저 리스트를 `GdsUserItem`, `GdsOutlinedButton`, `GdsPersonAvatar` 기반으로 변경
  - 빈 상태 UI를 `GdsEmptyState`로 변경

- 차단 목록을 모달에서도 사용할 수 있도록 `showBlockedUsersModal` 전역 함수를 추가했습니다용.
  - 데스크톱/비모바일 환경에서는 프로필 더보기의 `차단 목록` 진입 시 페이지 이동 대신 모달을 노출하도록 변경
  - `BlockedUsersView`에 `isModal` 옵션을 추가해 페이지/모달 레이아웃 패딩을 분리

- `User` 엔티티에 GDS 표시용 편의 getter를 추가했습니다용.
  - `handle`: `@url` 형태의 유저 핸들 반환
  - `personAvatar`: `GdsPersonAvatar` 생성
  - skeleton/mock 표시용 `User.empty()`의 `url` 값을 `lorem_ipsum`으로 설정

- GDS git dependency 변경 사항을 반영해 `pubspec.lock`을 업데이트했습니다용.

## 확인 방법

- 프로필 더보기 > 차단 목록 진입 (모바일은 페이지, 비모바일은 모달)